### PR TITLE
fix: migrate docs content config to Astro 6 format

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,0 +1,7 @@
+import { defineCollection } from "astro:content";
+import { docsLoader } from "@astrojs/starlight/loaders";
+import { docsSchema } from "@astrojs/starlight/schema";
+
+export const collections = {
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+};

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -1,6 +1,0 @@
-import { docsSchema } from "@astrojs/starlight/schema";
-import { defineCollection } from "astro:content";
-
-export const collections = {
-  docs: defineCollection({ schema: docsSchema() }),
-};


### PR DESCRIPTION
## Problem

The `Build docs` CI step fails with:

```
[LegacyContentConfigError] Found legacy content config file in "src/content/config.ts".
Please move this file to "src/content.config.ts" and ensure each collection has a loader defined.
```

## Root Cause

Astro 6 removed legacy content collections. The old `src/content/config.ts` format is no longer supported — collections must now use the Content Layer API with explicit loaders.

## Fix

- Moved `docs/src/content/config.ts` → `docs/src/content.config.ts`
- Added `docsLoader()` from `@astrojs/starlight/loaders` to the docs collection definition