### PR TITLE
fix: update Starlight social config to array syntax (v0.33.0+)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -15,12 +15,23 @@ export default defineConfig({
       },
       description:
         "Open-source unified CPaaS — WhatsApp, Telegram, SMS, RCS, Voice. Multi-provider. AI-native. Self-hostable.",
-      social: {
-        github:
-          "https://github.com/JINA-CODE-SYSTEMS/jina-connect-unified-cpaas",
-        discord: "https://discord.gg/jbN5cwKR",
-        "x.com": "https://x.com/tryjinaconnect",
-      },
+      social: [
+        {
+          icon: "github",
+          label: "GitHub",
+          href: "https://github.com/JINA-CODE-SYSTEMS/jina-connect-unified-cpaas",
+        },
+        {
+          icon: "discord",
+          label: "Discord",
+          href: "https://discord.gg/jbN5cwKR",
+        },
+        {
+          icon: "x.com",
+          label: "X",
+          href: "https://x.com/tryjinaconnect",
+        },
+      ],
       customCss: ["./src/styles/custom.css"],
       editLink: {
         baseUrl:


### PR DESCRIPTION
## Summary

Starlight v0.33.0 changed the `social` configuration option from object syntax to an array of `{ icon, label, href }` items ([changelog](https://github.com/withastro/starlight/blob/main/packages/starlight/CHANGELOG.md#0330)).

This was causing the docs CI build to fail with:
```
AstroUserError: Invalid config passed to starlight integration
```

## Changes

Converted `social` config in `docs/astro.config.mjs` from:
```js
social: {
  github: "https://github.com/...",
  discord: "https://discord.gg/...",
  "x.com": "https://x.com/...",
}
```
To:
```js
social: [
  { icon: "github", label: "GitHub", href: "https://github.com/..." },
  { icon: "discord", label: "Discord", href: "https://discord.gg/..." },
  { icon: "x.com", label: "X", href: "https://x.com/..." },
]
```

## Testing

- Ran `npx astro build` locally — 24 pages built successfully with no errors
- Pagefind search index built successfully
- Sitemap generated successfully