### PR TITLE
fix(broadcast): restrict 405 in BroadcastViewSet.create to the base c…

### DIFF
--- a/broadcast/tests/test_broadcast_create.py
+++ b/broadcast/tests/test_broadcast_create.py
@@ -28,3 +28,44 @@ class TestBroadcastCreateDisabled:
         """#124: POST /broadcast/ on base viewset returns 405."""
         response = auth_client.post("/broadcast/", {"name": "test"}, format="json")
         assert response.status_code == 405
+
+    def test_subclass_create_is_not_blocked_by_base_405(self):
+        """
+        Regression: BroadcastViewSet.create() must only short-circuit with 405
+        for the base class itself. Channel-specific subclasses (e.g.
+        WABroadcastViewSet) call super().create() and were previously blocked,
+        making it impossible to create any broadcast from any channel.
+        """
+        from rest_framework.test import APIRequestFactory
+
+        from broadcast.viewsets.broadcast import BroadcastViewSet
+
+        class DummyChannelBroadcastViewSet(BroadcastViewSet):
+            pass
+
+        factory = APIRequestFactory()
+        request = factory.post("/dummy/", {}, format="json")
+        view = DummyChannelBroadcastViewSet()
+        view.action_map = {"post": "create"}
+        view.request = view.initialize_request(request)
+        view.format_kwarg = None
+        view.action = "create"
+        view.kwargs = {}
+
+        # The base-class guard must NOT trigger for subclasses.
+        # We only assert the 405 short-circuit isn't returned; the real
+        # CreateModelMixin path is exercised in channel-specific test suites
+        # (e.g. wa/tests/) where full fixtures (WAApp, template, contacts)
+        # are available.
+        try:
+            response = view.create(view.request)
+        except Exception:
+            # Falling through to the real create path will raise because
+            # no queryset/serializer is configured on the dummy subclass.
+            # That is the expected, correct behaviour — the guard let us pass.
+            return
+
+        assert response.status_code != 405, (
+            "Subclass of BroadcastViewSet was incorrectly blocked by the "
+            "base-class 405 guard."
+        )

--- a/broadcast/tests/test_broadcast_create.py
+++ b/broadcast/tests/test_broadcast_create.py
@@ -29,6 +29,11 @@ class TestBroadcastCreateDisabled:
         response = auth_client.post("/broadcast/", {"name": "test"}, format="json")
         assert response.status_code == 405
 
+    def test_post_mobile_broadcast_returns_405(self, auth_client):
+        """POST /mobile/broadcast/ (MobileBroadcastViewSet) is also blocked — channel-specific endpoints must be used."""
+        response = auth_client.post("/mobile/broadcast/", {"name": "test"}, format="json")
+        assert response.status_code == 405
+
     def test_subclass_create_is_not_blocked_by_base_405(self):
         """
         Regression: BroadcastViewSet.create() must only short-circuit with 405

--- a/broadcast/tests/test_broadcast_create.py
+++ b/broadcast/tests/test_broadcast_create.py
@@ -34,25 +34,42 @@ class TestBroadcastCreateDisabled:
         response = auth_client.post("/mobile/broadcast/", {"name": "test"}, format="json")
         assert response.status_code == 405
 
-    def test_subclass_create_is_not_blocked_by_base_405(self):
+    def test_subclass_create_is_not_blocked_by_base_405(self, db):
         """
         Regression: BroadcastViewSet.create() must only short-circuit with 405
         for the base class itself. Channel-specific subclasses (e.g.
         WABroadcastViewSet) call super().create() and were previously blocked,
         making it impossible to create any broadcast from any channel.
         """
+        from django.contrib.auth import get_user_model
         from rest_framework.test import APIRequestFactory
 
         from broadcast.viewsets.broadcast import BroadcastViewSet
+        from tenants.models import Tenant, TenantRole, TenantUser
+
+        User = get_user_model()
+
+        # Create minimal user/tenant for request.user
+        tenant = Tenant.objects.create(name="Dummy Tenant")
+        user = User.objects.create_user(
+            username="dummy_user", email="dummy@test.local", mobile="+919999999999", password="pass"
+        )
+        role, _ = TenantRole.objects.get_or_create(
+            tenant=tenant, slug="owner", defaults={"name": "Owner", "priority": 100}
+        )
+        TenantUser.objects.create(user=user, tenant=tenant, role=role, is_active=True)
 
         class DummyChannelBroadcastViewSet(BroadcastViewSet):
             pass
 
         factory = APIRequestFactory()
         request = factory.post("/dummy/", {}, format="json")
+        # Force authenticate to avoid AnonymousUser issues
+        request.user = user
         view = DummyChannelBroadcastViewSet()
         view.action_map = {"post": "create"}
         view.request = view.initialize_request(request)
+        view.request.user = user  # Ensure user is set after initialization
         view.format_kwarg = None
         view.action = "create"
         view.kwargs = {}
@@ -62,14 +79,10 @@ class TestBroadcastCreateDisabled:
         # CreateModelMixin path is exercised in channel-specific test suites
         # (e.g. wa/tests/) where full fixtures (WAApp, template, contacts)
         # are available.
-        try:
-            response = view.create(view.request)
-        except Exception:
-            # Falling through to the real create path will raise because
-            # no queryset/serializer is configured on the dummy subclass.
-            # That is the expected, correct behaviour — the guard let us pass.
-            return
+        from rest_framework.exceptions import ValidationError
 
-        assert response.status_code != 405, (
-            "Subclass of BroadcastViewSet was incorrectly blocked by the base-class 405 guard."
-        )
+        with pytest.raises(ValidationError):
+            # Falling through to the real create path raises ValidationError from
+            # the serializer because the payload is empty. This proves the 405
+            # guard was bypassed and we reached the serializer layer.
+            view.create(view.request)

--- a/broadcast/tests/test_broadcast_create.py
+++ b/broadcast/tests/test_broadcast_create.py
@@ -71,6 +71,5 @@ class TestBroadcastCreateDisabled:
             return
 
         assert response.status_code != 405, (
-            "Subclass of BroadcastViewSet was incorrectly blocked by the "
-            "base-class 405 guard."
+            "Subclass of BroadcastViewSet was incorrectly blocked by the base-class 405 guard."
         )

--- a/broadcast/viewsets/broadcast.py
+++ b/broadcast/viewsets/broadcast.py
@@ -45,15 +45,13 @@ class BroadcastViewSet(BaseTenantModelViewSet):
     datetime_filter_fields = ["created_at", "scheduled_time"]
 
     def create(self, request, *args, **kwargs):
-        """Disabled on the base viewset only — channel-specific subclasses handle create."""
-        if type(self) is BroadcastViewSet:
+        """Disabled on the generic base — channel-specific subclasses handle create."""
+        if type(self).__name__ in {"BroadcastViewSet", "MobileBroadcastViewSet"}:
             return Response(
                 {"detail": "Use a channel-specific broadcast endpoint to create broadcasts."},
                 status=drf_status.HTTP_405_METHOD_NOT_ALLOWED,
             )
-        # Subclass (e.g. WABroadcastViewSet) — defer to default ModelViewSet.create
-        from rest_framework.mixins import CreateModelMixin
-        return CreateModelMixin.create(self, request, *args, **kwargs)
+        return super().create(request, *args, **kwargs)
 
     filterset_fields = {
         "status": ["exact", "in"],

--- a/broadcast/viewsets/broadcast.py
+++ b/broadcast/viewsets/broadcast.py
@@ -45,11 +45,15 @@ class BroadcastViewSet(BaseTenantModelViewSet):
     datetime_filter_fields = ["created_at", "scheduled_time"]
 
     def create(self, request, *args, **kwargs):
-        """Disabled on base viewset — use channel-specific broadcast endpoints."""
-        return Response(
-            {"detail": "Use a channel-specific broadcast endpoint to create broadcasts."},
-            status=drf_status.HTTP_405_METHOD_NOT_ALLOWED,
-        )
+        """Disabled on the base viewset only — channel-specific subclasses handle create."""
+        if type(self) is BroadcastViewSet:
+            return Response(
+                {"detail": "Use a channel-specific broadcast endpoint to create broadcasts."},
+                status=drf_status.HTTP_405_METHOD_NOT_ALLOWED,
+            )
+        # Subclass (e.g. WABroadcastViewSet) — defer to default ModelViewSet.create
+        from rest_framework.mixins import CreateModelMixin
+        return CreateModelMixin.create(self, request, *args, **kwargs)
 
     filterset_fields = {
         "status": ["exact", "in"],

--- a/broadcast/viewsets/broadcast.py
+++ b/broadcast/viewsets/broadcast.py
@@ -45,7 +45,20 @@ class BroadcastViewSet(BaseTenantModelViewSet):
     datetime_filter_fields = ["created_at", "scheduled_time"]
 
     def create(self, request, *args, **kwargs):
-        """Disabled on the generic base — channel-specific subclasses handle create."""
+        """Block create on the generic base viewsets; delegate for channel subclasses.
+
+        ``BroadcastViewSet`` and ``MobileBroadcastViewSet`` are channel-agnostic
+        and must not create broadcasts directly — callers must use a
+        channel-specific endpoint (WA, SMS, RCS, Telegram, ...).
+
+        Channel subclasses are expected to either:
+          * override ``create()`` and call ``super().create(...)`` (e.g.
+            ``WABroadcastViewSet`` does this to attach low-balance warnings), or
+          * delegate directly to ``CreateModelMixin.create`` themselves.
+
+        The ``super().create(...)`` call below is the path taken by subclasses
+        in the first category and is therefore not dead code.
+        """
         if type(self).__name__ in {"BroadcastViewSet", "MobileBroadcastViewSet"}:
             return Response(
                 {"detail": "Use a channel-specific broadcast endpoint to create broadcasts."},

--- a/docs/src/content/docs/api/broadcast.mdx
+++ b/docs/src/content/docs/api/broadcast.mdx
@@ -7,10 +7,24 @@ import { Aside } from "@astrojs/starlight/components";
 
 ## Endpoints
 
+<Aside type="caution">
+  The base `/broadcast/` endpoint **does not accept POST** requests. Use channel-specific endpoints below to create broadcasts.
+</Aside>
+
+### Channel-Specific Endpoints
+
 | Method | Endpoint | Description |
 |---|---|---|
-| `GET` | `/broadcast/` | List broadcasts |
-| `POST` | `/broadcast/` | Create broadcast |
+| `POST` | `/wa/broadcast/` | Create WhatsApp broadcast |
+| `POST` | `/sms/broadcast/` | Create SMS broadcast |
+| `POST` | `/rcs/broadcast/` | Create RCS broadcast |
+| `POST` | `/telegram/broadcast/` | Create Telegram broadcast |
+
+### Read/Update/Delete Endpoints
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/broadcast/` | List all broadcasts (cross-channel) |
 | `GET` | `/broadcast/{id}/` | Get broadcast details |
 | `PUT` | `/broadcast/{id}/` | Update broadcast |
 | `DELETE` | `/broadcast/{id}/` | Delete broadcast |
@@ -18,18 +32,40 @@ import { Aside } from "@astrojs/starlight/components";
 | `GET` | `/broadcast/dashboard/` | Campaign analytics dashboard |
 | `GET` | `/broadcast/url-tracking/` | URL click tracking |
 
+<Aside type="note">
+  `/mobile/broadcast/` (mobile client endpoint) also returns **405 Method Not Allowed** for POST requests.
+</Aside>
+
 ## Create Broadcast
 
+### WhatsApp Broadcast
+
 ```bash
-curl -X POST http://localhost:8000/broadcast/ \
+curl -X POST http://localhost:8000/wa/broadcast/ \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Summer Sale Campaign",
-    "platform": "WHATSAPP",
-    "template_name": "summer_sale",
+    "template_number": 123,
     "recipients": ["contact-uuid-1", "contact-uuid-2"],
-    "scheduled_at": "2024-07-01T10:00:00Z"
+    "placeholder_data": {"1": "John", "2": "25% off"},
+    "scheduled_time": "2024-07-01T10:00:00Z",
+    "status": "SCHEDULED"
+  }'
+```
+
+### SMS/RCS/Telegram Broadcast
+
+```bash
+curl -X POST http://localhost:8000/sms/broadcast/ \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Flash Sale Alert",
+    "message": "Hi {{1}}, enjoy {{2}} on all items today!",
+    "recipients": ["contact-uuid-1", "contact-uuid-2"],
+    "placeholder_data": {"1": "John", "2": "25% off"},
+    "status": "QUEUED"
   }'
 ```
 


### PR DESCRIPTION
…lass so channel subclasses (e.g. WABroadcastViewSet) can create broadcasts