### PR TITLE
feat(telegram): add buttons support and fix non-WA template lifecycle

### DIFF
--- a/docs/src/content/docs/api/templates.mdx
+++ b/docs/src/content/docs/api/templates.mdx
@@ -7,6 +7,8 @@ description: WhatsApp message template management with full lifecycle tracking.
 
 WhatsApp Business API requires pre-approved templates for business-initiated conversations. Jina Connect manages the full template lifecycle across BSPs.
 
+Channel-scoped template endpoints for SMS, Telegram, and RCS reuse the same template model, but they do not wait for BSP approval. Those templates are created immediately as `APPROVED` with `needs_sync=false` because no WhatsApp BSP sync is required.
+
 ## Endpoints
 
 | Method | Endpoint | Description |
@@ -59,6 +61,11 @@ curl -X POST http://localhost:8000/wa/v2/templates/ \
 | `PAUSED` | Temporarily paused by BSP |
 | `DISABLED` | Permanently disabled |
 | `FAILED` | Submission failed |
+
+This lifecycle applies to WhatsApp templates created through `/wa/v2/templates/`.
+
+- WhatsApp templates start as `DRAFT`, keep `needs_sync=true`, and move through the BSP approval flow.
+- SMS, Telegram, and RCS templates created through their channel-specific endpoints start as `APPROVED` with `needs_sync=false`.
 
 ## Button Types
 

--- a/docs/src/content/docs/channels/telegram.mdx
+++ b/docs/src/content/docs/channels/telegram.mdx
@@ -56,9 +56,23 @@ Each tenant can register their own Telegram bot. Messages are sent via the Teleg
 
 ## Sending Messages
 
-Messages are sent through the message sender service (`telegram/services/message_sender.py`):
+Messages can be sent ad hoc through `POST /telegram/v1/messages/send/` or through the message sender service (`telegram/services/message_sender.py`):
 
 ```bash
+# Ad hoc send
+curl -X POST http://localhost:8000/telegram/v1/messages/send/ \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "99999",
+    "text": "Choose an option",
+    "buttons": [
+      {"type": "URL", "text": "Visit site", "url": "https://example.com"},
+      {"type": "PHONE_NUMBER", "text": "Call support", "phone_number": "+911234567890"},
+      {"type": "QUICK_REPLY", "text": "Track order"}
+    ]
+  }'
+
 # Via MCP tool (simplest)
 # Use the send_message tool with channel="TELEGRAM"
 
@@ -71,6 +85,39 @@ curl -X POST http://localhost:8000/broadcast/ \
     "platform": "TELEGRAM",
     "message_text": "Hello from Jina Connect!",
     "recipients": ["contact-uuid-1", "contact-uuid-2"]
+  }'
+```
+
+`buttons` are converted into Telegram `inline_keyboard` rows with one button per row:
+
+- `URL` maps to a Telegram URL button.
+- `PHONE_NUMBER` maps to a `tel:` URL button.
+- `QUICK_REPLY`, `COPY_CODE`, and `OTP` map to `callback_data` buttons.
+- Unknown button types fall back to `callback_data` with the `action:` prefix.
+
+Telegram limits `callback_data` to 64 bytes. Jina Connect truncates oversized values safely on UTF-8 byte boundaries before sending.
+
+The ad hoc endpoint also accepts frontend media aliases in place of `media_url`:
+
+- `photo`
+- `video`
+- `document`
+
+When both `media_url` and one of these alias fields are supplied, `media_url` takes precedence.
+
+Example media payload with buttons:
+
+```bash
+curl -X POST http://localhost:8000/telegram/v1/messages/send/ \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chat_id": "99999",
+    "photo": "https://example.com/invoice.jpg",
+    "text": "Invoice ready",
+    "buttons": [
+      {"type": "QUICK_REPLY", "text": "Acknowledge"}
+    ]
   }'
 ```
 

--- a/telegram/services/bot_client.py
+++ b/telegram/services/bot_client.py
@@ -212,6 +212,7 @@ class TelegramBotClient:
         document: str,
         caption: Optional[str] = None,
         parse_mode: Optional[str] = None,
+        reply_markup: Optional[dict] = None,
         **kwargs,
     ) -> dict:
         """Send a document (``sendDocument``). ``document`` can be a URL or file_id."""
@@ -220,6 +221,8 @@ class TelegramBotClient:
             data["caption"] = caption
         if parse_mode:
             data["parse_mode"] = parse_mode
+        if reply_markup:
+            data["reply_markup"] = reply_markup
         data.update(kwargs)
         return self._request("sendDocument", data)
 

--- a/telegram/services/keyboard_builder.py
+++ b/telegram/services/keyboard_builder.py
@@ -14,6 +14,46 @@ from telegram.constants import CALLBACK_DATA_MAX_LENGTH, CALLBACK_DATA_VERSION
 _CALLBACK_RE = re.compile(r"^(?P<version>v\d+):(?P<action>\w+):(?P<id>[^:]+):(?P<nonce>[^:]+)$")
 
 
+def _truncate_callback_data(data: str) -> str:
+    """Trim callback_data to Telegram's byte limit without splitting UTF-8 codepoints."""
+    encoded = data.encode("utf-8")
+    if len(encoded) <= CALLBACK_DATA_MAX_LENGTH:
+        return data
+
+    ellipsis = "..."
+    max_prefix_bytes = CALLBACK_DATA_MAX_LENGTH - len(ellipsis.encode("utf-8"))
+    truncated = encoded[:max_prefix_bytes].decode("utf-8", errors="ignore")
+    return f"{truncated}{ellipsis}"
+
+
+def build_template_button_keyboard(buttons: list[dict]) -> Optional[dict]:
+    """Convert flat channel-template button specs into Telegram inline keyboard markup."""
+    rows = []
+    for button in buttons:
+        text = (button.get("text") or "").strip()
+        if not text:
+            continue
+
+        button_type = (button.get("type") or "").upper()
+        normalized = {"text": text}
+
+        if button_type == "URL" and button.get("url"):
+            normalized["url"] = button["url"]
+        elif button_type == "PHONE_NUMBER" and button.get("phone_number"):
+            normalized["url"] = f"tel:{button['phone_number']}"
+        elif button_type in ("QUICK_REPLY", "COPY_CODE", "OTP"):
+            normalized["callback_data"] = _truncate_callback_data(f"{button_type.lower()}:{text}")
+        else:
+            normalized["callback_data"] = _truncate_callback_data(f"action:{text}")
+
+        rows.append([normalized])
+
+    if not rows:
+        return None
+
+    return build_inline_keyboard(rows)
+
+
 def build_inline_keyboard(buttons: list[list[dict]]) -> dict:
     """
     Build a Telegram InlineKeyboardMarkup from a nested button spec.

--- a/telegram/services/message_sender.py
+++ b/telegram/services/message_sender.py
@@ -60,10 +60,13 @@ class TelegramMessageSender(BaseChannelAdapter):
                 parse_mode=parse_mode,
                 reply_markup=reply_markup,
             )
+            request_payload = {"text": text}
+            if reply_markup:
+                request_payload["reply_markup"] = reply_markup
             outbound = self._persist_outbound(
                 chat_id=int(chat_id),
                 message_type="TEXT",
-                request_payload={"text": text},
+                request_payload=request_payload,
                 result=result,
                 contact=kwargs.get("contact"),
             )
@@ -86,6 +89,9 @@ class TelegramMessageSender(BaseChannelAdapter):
         """Send a media message (photo, document, video, audio, voice)."""
         if err := self._check_rate_limit():
             return err
+
+        reply_markup = kwargs.get("reply_markup")
+        parse_mode = kwargs.get("parse_mode")
 
         # Validate URL scheme
         from urllib.parse import urlparse
@@ -120,11 +126,18 @@ class TelegramMessageSender(BaseChannelAdapter):
             send_kwargs = {"chat_id": int(chat_id), media_key: media_url}
             if caption:
                 send_kwargs["caption"] = caption
+            if parse_mode:
+                send_kwargs["parse_mode"] = parse_mode
+            if reply_markup:
+                send_kwargs["reply_markup"] = reply_markup
             result = send_fn(**send_kwargs)
+            request_payload = {media_key: media_url, "caption": caption}
+            if reply_markup:
+                request_payload["reply_markup"] = reply_markup
             outbound = self._persist_outbound(
                 chat_id=int(chat_id),
                 message_type=media_type.upper(),
-                request_payload={media_key: media_url, "caption": caption},
+                request_payload=request_payload,
                 result=result,
                 contact=kwargs.get("contact"),
             )

--- a/telegram/tests/test_keyboard_builder.py
+++ b/telegram/tests/test_keyboard_builder.py
@@ -7,6 +7,7 @@ import pytest
 from telegram.services.keyboard_builder import (
     build_callback_data,
     build_inline_keyboard,
+    build_template_button_keyboard,
     parse_callback_data,
 )
 
@@ -56,6 +57,61 @@ class TestBuildCallbackData:
     def test_exceeds_limit_raises(self):
         with pytest.raises(ValueError, match="exceeds 64 bytes"):
             build_callback_data("action", "x" * 60, "nonce")
+
+
+class TestBuildTemplateButtonKeyboard:
+    def test_url_and_phone_number_buttons(self):
+        result = build_template_button_keyboard(
+            [
+                {"type": "URL", "text": "Visit", "url": "https://example.com"},
+                {"type": "PHONE_NUMBER", "text": "Call", "phone_number": "+911234567890"},
+            ]
+        )
+
+        assert result == {
+            "inline_keyboard": [
+                [{"text": "Visit", "url": "https://example.com"}],
+                [{"text": "Call", "url": "tel:+911234567890"}],
+            ]
+        }
+
+    @pytest.mark.parametrize(
+        ("button_type", "expected_callback"),
+        [
+            ("QUICK_REPLY", "quick_reply:Yes"),
+            ("COPY_CODE", "copy_code:Code"),
+            ("OTP", "otp:123456"),
+        ],
+    )
+    def test_interactive_buttons_use_callback_data(self, button_type, expected_callback):
+        button_text = expected_callback.split(":", 1)[1]
+        result = build_template_button_keyboard([{"type": button_type, "text": button_text}])
+
+        assert result["inline_keyboard"][0][0]["callback_data"] == expected_callback
+
+    def test_unknown_button_type_falls_back_to_action_callback(self):
+        result = build_template_button_keyboard([{"type": "UNKNOWN", "text": "Do it"}])
+
+        assert result["inline_keyboard"][0][0]["callback_data"] == "action:Do it"
+
+    def test_empty_text_buttons_are_skipped_and_empty_markup_returns_none(self):
+        assert build_template_button_keyboard([{"type": "URL", "text": "   ", "url": "https://example.com"}]) is None
+
+        result = build_template_button_keyboard(
+            [
+                {"type": "URL", "text": "", "url": "https://example.com"},
+                {"type": "QUICK_REPLY", "text": "Keep"},
+            ]
+        )
+
+        assert result == {"inline_keyboard": [[{"text": "Keep", "callback_data": "quick_reply:Keep"}]]}
+
+    def test_multibyte_callback_data_is_truncated_safely(self):
+        result = build_template_button_keyboard([{"type": "QUICK_REPLY", "text": "🙂" * 40}])
+
+        callback_data = result["inline_keyboard"][0][0]["callback_data"]
+        assert callback_data.endswith("...")
+        assert len(callback_data.encode("utf-8")) <= 64
 
 
 class TestParseCallbackData:

--- a/telegram/tests/test_send_message.py
+++ b/telegram/tests/test_send_message.py
@@ -88,6 +88,45 @@ class TestTelegramSendEndpoint:
         assert resp.status_code == 200
         assert resp.data["success"] is True
 
+    def test_send_text_buttons_builds_reply_markup(self, api_client, bot_app, monkeypatch):
+        """Buttons are converted to Telegram inline_keyboard and passed to send_text."""
+        from telegram.services.message_sender import TelegramMessageSender
+
+        captured = {}
+
+        def fake_send_text(self, chat_id, text, **kwargs):
+            captured["chat_id"] = chat_id
+            captured["text"] = text
+            captured["reply_markup"] = kwargs.get("reply_markup")
+            return {"success": True, "message_id": "12345", "outbound_id": "fake-uuid"}
+
+        monkeypatch.setattr(TelegramMessageSender, "send_text", fake_send_text)
+
+        resp = api_client.post(
+            "/telegram/v1/messages/send/",
+            {
+                "chat_id": "99999",
+                "text": "Choose one",
+                "buttons": [
+                    {"type": "URL", "text": "Visit", "url": "https://example.com"},
+                    {"type": "PHONE_NUMBER", "text": "Call", "phone_number": "+911234567890"},
+                    {"type": "QUICK_REPLY", "text": "Yes"},
+                ],
+            },
+            format="json",
+        )
+
+        assert resp.status_code == 200
+        assert captured["chat_id"] == "99999"
+        assert captured["text"] == "Choose one"
+        assert captured["reply_markup"] == {
+            "inline_keyboard": [
+                [{"text": "Visit", "url": "https://example.com"}],
+                [{"text": "Call", "url": "tel:+911234567890"}],
+                [{"text": "Yes", "callback_data": "quick_reply:Yes"}],
+            ]
+        }
+
     def test_send_media_success(self, api_client, bot_app, monkeypatch):
         """POST /telegram/v1/messages/send/ with media_url returns 200."""
         from telegram.services.message_sender import TelegramMessageSender
@@ -102,6 +141,115 @@ class TestTelegramSendEndpoint:
 
         assert resp.status_code == 200
         assert resp.data["success"] is True
+
+    @pytest.mark.parametrize(
+        ("field_name", "media_url", "expected_type"),
+        [
+            ("photo", "https://example.com/img.jpg", "photo"),
+            ("video", "https://example.com/video.mp4", "video"),
+            ("document", "https://example.com/file.pdf", "document"),
+        ],
+    )
+    def test_media_aliases_route_to_send_media(
+        self,
+        api_client,
+        bot_app,
+        monkeypatch,
+        field_name,
+        media_url,
+        expected_type,
+    ):
+        """Frontend media aliases map to the correct Telegram media_type."""
+        from telegram.services.message_sender import TelegramMessageSender
+
+        captured = {}
+
+        def fake_send_media(self, chat_id, media_type, media_url, caption=None, **kwargs):
+            captured["chat_id"] = chat_id
+            captured["media_type"] = media_type
+            captured["media_url"] = media_url
+            captured["caption"] = caption
+            captured["reply_markup"] = kwargs.get("reply_markup")
+            return {"success": True, "message_id": "12346", "outbound_id": "fake-uuid"}
+
+        monkeypatch.setattr(TelegramMessageSender, "send_media", fake_send_media)
+
+        resp = api_client.post(
+            "/telegram/v1/messages/send/",
+            {"chat_id": "99999", field_name: media_url},
+            format="json",
+        )
+
+        assert resp.status_code == 200
+        assert captured["chat_id"] == "99999"
+        assert captured["media_type"] == expected_type
+        assert captured["media_url"] == media_url
+        assert captured["caption"] is None
+        assert captured["reply_markup"] is None
+
+    def test_media_url_takes_precedence_over_alias_fields(self, api_client, bot_app, monkeypatch):
+        """media_url remains the source of truth when alias fields are also present."""
+        from telegram.services.message_sender import TelegramMessageSender
+
+        captured = {}
+
+        def fake_send_media(self, chat_id, media_type, media_url, caption=None, **kwargs):
+            captured["media_type"] = media_type
+            captured["media_url"] = media_url
+            return {"success": True, "message_id": "12346", "outbound_id": "fake-uuid"}
+
+        monkeypatch.setattr(TelegramMessageSender, "send_media", fake_send_media)
+
+        resp = api_client.post(
+            "/telegram/v1/messages/send/",
+            {
+                "chat_id": "99999",
+                "media_url": "https://example.com/primary.pdf",
+                "media_type": "document",
+                "photo": "https://example.com/ignored.jpg",
+            },
+            format="json",
+        )
+
+        assert resp.status_code == 200
+        assert captured["media_type"] == "document"
+        assert captured["media_url"] == "https://example.com/primary.pdf"
+
+    def test_send_media_with_buttons_passes_reply_markup(self, api_client, bot_app, monkeypatch):
+        """Buttons are preserved when sending media payloads."""
+        from telegram.services.message_sender import TelegramMessageSender
+
+        captured = {}
+
+        def fake_send_media(self, chat_id, media_type, media_url, caption=None, **kwargs):
+            captured["chat_id"] = chat_id
+            captured["media_type"] = media_type
+            captured["media_url"] = media_url
+            captured["caption"] = caption
+            captured["reply_markup"] = kwargs.get("reply_markup")
+            return {"success": True, "message_id": "12346", "outbound_id": "fake-uuid"}
+
+        monkeypatch.setattr(TelegramMessageSender, "send_media", fake_send_media)
+
+        resp = api_client.post(
+            "/telegram/v1/messages/send/",
+            {
+                "chat_id": "99999",
+                "photo": "https://example.com/img.jpg",
+                "text": "See attachment",
+                "buttons": [{"type": "QUICK_REPLY", "text": "Acknowledge"}],
+            },
+            format="json",
+        )
+
+        assert resp.status_code == 200
+        assert captured["chat_id"] == "99999"
+        assert captured["media_type"] == "photo"
+        assert captured["media_url"] == "https://example.com/img.jpg"
+        assert captured["caption"] == "See attachment"
+        assert captured["reply_markup"] == {
+            "inline_keyboard": [[{"text": "Acknowledge", "callback_data": "quick_reply:Acknowledge"}]]
+        }
 
     def test_rejects_empty_payload(self, api_client, bot_app):
         """text and media_url both absent → 400."""

--- a/telegram/viewsets/message.py
+++ b/telegram/viewsets/message.py
@@ -1,10 +1,15 @@
 """Telegram ad-hoc message sending viewset."""
 
+import logging
+
 from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from abstract.viewsets.base import BaseTenantModelViewSet
+from telegram.services.keyboard_builder import build_template_button_keyboard
+
+logger = logging.getLogger(__name__)
 
 
 class TelegramSendMessageSerializer(serializers.Serializer):
@@ -125,21 +130,19 @@ class TelegramMessageViewSet(BaseTenantModelViewSet):
                 media_url = data.get("document")
                 media_type = "document"
 
-        # Log incoming request for debugging
-        import logging
-
-        logger = logging.getLogger(__name__)
-        text_preview = text[:50] if text else ""
-        logger.info(
-            f"[TelegramMessage] Sending to contact_id={data.get('contact_id')}, "
-            f"chat_id={chat_id}, text={text_preview}..., buttons={buttons}, media_url={media_url}"
+        logger.debug(
+            "[TelegramMessage] send contact_id=%s chat_id=%s has_text=%s has_buttons=%s media_type=%s has_media=%s",
+            data.get("contact_id"),
+            chat_id,
+            bool(text),
+            bool(buttons),
+            media_type,
+            bool(media_url),
         )
 
-        # Build reply_markup from buttons if provided
         reply_markup = None
         if buttons:
-            reply_markup = self._convert_buttons_to_telegram_keyboard(buttons)
-            logger.info(f"[TelegramMessage] Built reply_markup: {reply_markup}")
+            reply_markup = build_template_button_keyboard(buttons)
 
         if media_url:
             result = sender.send_media(
@@ -148,6 +151,7 @@ class TelegramMessageViewSet(BaseTenantModelViewSet):
                 media_url=media_url,
                 caption=text or None,
                 contact=contact,
+                reply_markup=reply_markup,
             )
         else:
             result = sender.send_text(
@@ -159,59 +163,3 @@ class TelegramMessageViewSet(BaseTenantModelViewSet):
 
         resp_status = status.HTTP_200_OK if result.get("success") else status.HTTP_400_BAD_REQUEST
         return Response(result, status=resp_status)
-
-    def _convert_buttons_to_telegram_keyboard(self, buttons: list[dict]) -> dict:
-        """
-        Convert WATemplate button format to Telegram inline_keyboard format.
-
-        WATemplate buttons:
-        [
-            {"type": "QUICK_REPLY", "text": "Yes"},
-            {"type": "URL", "text": "Visit", "url": "https://example.com"},
-            {"type": "PHONE_NUMBER", "text": "Call", "phone_number": "+911234567890"}
-        ]
-
-        Telegram inline_keyboard:
-        {
-            "inline_keyboard": [
-                [{"text": "Yes", "callback_data": "quick_reply:Yes"}],
-                [{"text": "Visit", "url": "https://example.com"}],
-                [{"text": "Call", "url": "tel:+911234567890"}]
-            ]
-        }
-        """
-        rows = []
-        for btn in buttons:
-            btn_type = btn.get("type", "").upper()
-            text = btn.get("text", "")
-
-            if not text:
-                continue  # Skip buttons without text
-
-            telegram_btn = {"text": text}
-
-            if btn_type == "URL" and btn.get("url"):
-                telegram_btn["url"] = btn["url"]
-            elif btn_type == "PHONE_NUMBER" and btn.get("phone_number"):
-                # Telegram doesn't have native phone button in inline keyboards
-                # Use URL with tel: scheme
-                telegram_btn["url"] = f"tel:{btn['phone_number']}"
-            elif btn_type in ("QUICK_REPLY", "COPY_CODE", "OTP"):
-                # Use callback_data for quick reply buttons
-                # Format: button_type:button_text (truncated to 64 bytes)
-                callback_data = f"{btn_type.lower()}:{text}"
-                if len(callback_data.encode("utf-8")) > 64:
-                    # Truncate if too long
-                    callback_data = callback_data[:61] + "..."
-                telegram_btn["callback_data"] = callback_data
-            else:
-                # Default: treat as callback button
-                callback_data = f"action:{text}"
-                if len(callback_data.encode("utf-8")) > 64:
-                    callback_data = callback_data[:61] + "..."
-                telegram_btn["callback_data"] = callback_data
-
-            # Each button on its own row
-            rows.append([telegram_btn])
-
-        return {"inline_keyboard": rows}

--- a/telegram/viewsets/message.py
+++ b/telegram/viewsets/message.py
@@ -32,7 +32,7 @@ class TelegramSendMessageSerializer(serializers.Serializer):
         has_media = bool(
             attrs.get("media_url") or attrs.get("photo") or attrs.get("video") or attrs.get("document")
         )
-        
+
         if not has_text and not has_media:
             raise serializers.ValidationError("Either 'text' or media (media_url/photo/video/document) must be provided.")
         if not attrs.get("chat_id") and not attrs.get("contact_id"):
@@ -112,7 +112,7 @@ class TelegramMessageViewSet(BaseTenantModelViewSet):
         media_url = data.get("media_url")
         media_type = data.get("media_type", "photo")
         buttons = data.get("buttons")
-        
+
         # Handle frontend media format (photo/video/document fields)
         if not media_url:
             if data.get("photo"):

--- a/telegram/viewsets/message.py
+++ b/telegram/viewsets/message.py
@@ -17,10 +17,24 @@ class TelegramSendMessageSerializer(serializers.Serializer):
         required=False,
     )
     contact_id = serializers.IntegerField(required=False, help_text="TenantContact ID for inbox tracking")
+    buttons = serializers.ListField(
+        child=serializers.DictField(),
+        required=False,
+        help_text="Array of button objects (type, text, url, phone_number)",
+    )
+    # Frontend sends media via these fields
+    photo = serializers.URLField(required=False, help_text="Photo URL (alternative to media_url)")
+    video = serializers.URLField(required=False, help_text="Video URL (alternative to media_url)")
+    document = serializers.URLField(required=False, help_text="Document URL (alternative to media_url)")
 
     def validate(self, attrs):
-        if not attrs.get("text") and not attrs.get("media_url"):
-            raise serializers.ValidationError("Either 'text' or 'media_url' must be provided.")
+        has_text = bool(attrs.get("text"))
+        has_media = bool(
+            attrs.get("media_url") or attrs.get("photo") or attrs.get("video") or attrs.get("document")
+        )
+        
+        if not has_text and not has_media:
+            raise serializers.ValidationError("Either 'text' or media (media_url/photo/video/document) must be provided.")
         if not attrs.get("chat_id") and not attrs.get("contact_id"):
             raise serializers.ValidationError("Either 'chat_id' or 'contact_id' must be provided.")
         return attrs
@@ -97,6 +111,31 @@ class TelegramMessageViewSet(BaseTenantModelViewSet):
         text = data.get("text", "")
         media_url = data.get("media_url")
         media_type = data.get("media_type", "photo")
+        buttons = data.get("buttons")
+        
+        # Handle frontend media format (photo/video/document fields)
+        if not media_url:
+            if data.get("photo"):
+                media_url = data.get("photo")
+                media_type = "photo"
+            elif data.get("video"):
+                media_url = data.get("video")
+                media_type = "video"
+            elif data.get("document"):
+                media_url = data.get("document")
+                media_type = "document"
+
+        # Log incoming request for debugging
+        import logging
+        logger = logging.getLogger(__name__)
+        text_preview = text[:50] if text else ""
+        logger.info(f"[TelegramMessage] Sending to contact_id={data.get('contact_id')}, chat_id={chat_id}, text={text_preview}..., buttons={buttons}, media_url={media_url}")
+
+        # Build reply_markup from buttons if provided
+        reply_markup = None
+        if buttons:
+            reply_markup = self._convert_buttons_to_telegram_keyboard(buttons)
+            logger.info(f"[TelegramMessage] Built reply_markup: {reply_markup}")
 
         if media_url:
             result = sender.send_media(
@@ -111,7 +150,64 @@ class TelegramMessageViewSet(BaseTenantModelViewSet):
                 chat_id=chat_id,
                 text=text,
                 contact=contact,
+                reply_markup=reply_markup,
             )
 
         resp_status = status.HTTP_200_OK if result.get("success") else status.HTTP_400_BAD_REQUEST
         return Response(result, status=resp_status)
+
+    def _convert_buttons_to_telegram_keyboard(self, buttons: list[dict]) -> dict:
+        """
+        Convert WATemplate button format to Telegram inline_keyboard format.
+
+        WATemplate buttons:
+        [
+            {"type": "QUICK_REPLY", "text": "Yes"},
+            {"type": "URL", "text": "Visit", "url": "https://example.com"},
+            {"type": "PHONE_NUMBER", "text": "Call", "phone_number": "+911234567890"}
+        ]
+
+        Telegram inline_keyboard:
+        {
+            "inline_keyboard": [
+                [{"text": "Yes", "callback_data": "quick_reply:Yes"}],
+                [{"text": "Visit", "url": "https://example.com"}],
+                [{"text": "Call", "url": "tel:+911234567890"}]
+            ]
+        }
+        """
+        rows = []
+        for btn in buttons:
+            btn_type = btn.get("type", "").upper()
+            text = btn.get("text", "")
+
+            if not text:
+                continue  # Skip buttons without text
+
+            telegram_btn = {"text": text}
+
+            if btn_type == "URL" and btn.get("url"):
+                telegram_btn["url"] = btn["url"]
+            elif btn_type == "PHONE_NUMBER" and btn.get("phone_number"):
+                # Telegram doesn't have native phone button in inline keyboards
+                # Use URL with tel: scheme
+                telegram_btn["url"] = f"tel:{btn['phone_number']}"
+            elif btn_type in ("QUICK_REPLY", "COPY_CODE", "OTP"):
+                # Use callback_data for quick reply buttons
+                # Format: button_type:button_text (truncated to 64 bytes)
+                callback_data = f"{btn_type.lower()}:{text}"
+                if len(callback_data.encode("utf-8")) > 64:
+                    # Truncate if too long
+                    callback_data = callback_data[:61] + "..."
+                telegram_btn["callback_data"] = callback_data
+            else:
+                # Default: treat as callback button
+                callback_data = f"action:{text}"
+                if len(callback_data.encode("utf-8")) > 64:
+                    callback_data = callback_data[:61] + "..."
+                telegram_btn["callback_data"] = callback_data
+
+            # Each button on its own row
+            rows.append([telegram_btn])
+
+        return {"inline_keyboard": rows}

--- a/telegram/viewsets/message.py
+++ b/telegram/viewsets/message.py
@@ -34,9 +34,13 @@ class TelegramSendMessageSerializer(serializers.Serializer):
         )
 
         if not has_text and not has_media:
-            raise serializers.ValidationError("Either 'text' or media (media_url/photo/video/document) must be provided.")
+            raise serializers.ValidationError(
+                "Either 'text' or media (media_url/photo/video/document) must be provided."
+            )
         if not attrs.get("chat_id") and not attrs.get("contact_id"):
-            raise serializers.ValidationError("Either 'chat_id' or 'contact_id' must be provided.")
+            raise serializers.ValidationError(
+                "Either 'chat_id' or 'contact_id' must be provided."
+            )
         return attrs
 
 
@@ -127,9 +131,13 @@ class TelegramMessageViewSet(BaseTenantModelViewSet):
 
         # Log incoming request for debugging
         import logging
+
         logger = logging.getLogger(__name__)
         text_preview = text[:50] if text else ""
-        logger.info(f"[TelegramMessage] Sending to contact_id={data.get('contact_id')}, chat_id={chat_id}, text={text_preview}..., buttons={buttons}, media_url={media_url}")
+        logger.info(
+            f"[TelegramMessage] Sending to contact_id={data.get('contact_id')}, "
+            f"chat_id={chat_id}, text={text_preview}..., buttons={buttons}, media_url={media_url}"
+        )
 
         # Build reply_markup from buttons if provided
         reply_markup = None

--- a/telegram/viewsets/message.py
+++ b/telegram/viewsets/message.py
@@ -29,18 +29,14 @@ class TelegramSendMessageSerializer(serializers.Serializer):
 
     def validate(self, attrs):
         has_text = bool(attrs.get("text"))
-        has_media = bool(
-            attrs.get("media_url") or attrs.get("photo") or attrs.get("video") or attrs.get("document")
-        )
+        has_media = bool(attrs.get("media_url") or attrs.get("photo") or attrs.get("video") or attrs.get("document"))
 
         if not has_text and not has_media:
             raise serializers.ValidationError(
                 "Either 'text' or media (media_url/photo/video/document) must be provided."
             )
         if not attrs.get("chat_id") and not attrs.get("contact_id"):
-            raise serializers.ValidationError(
-                "Either 'chat_id' or 'contact_id' must be provided."
-            )
+            raise serializers.ValidationError("Either 'chat_id' or 'contact_id' must be provided.")
         return attrs
 
 

--- a/wa/tests/test_channel_templates.py
+++ b/wa/tests/test_channel_templates.py
@@ -62,14 +62,15 @@ TEMPLATE_PAYLOAD = {
 @pytest.mark.django_db
 class TestSMSTemplateViewSet:
     def test_create_sets_platform_and_tenant(self, api_client, tenant_user):
-        """POST /sms/v1/templates/ creates template with platform=SMS and correct tenant (#21)."""
+        """POST /sms/v1/templates/ creates an approved SMS template for the tenant (#21)."""
         resp = api_client.post("/sms/v1/templates/", TEMPLATE_PAYLOAD, format="json")
 
         assert resp.status_code == 201
         tpl = WATemplate.objects.get(pk=resp.data["id"])
         assert tpl.platform == "SMS"
         assert tpl.tenant == tenant_user.tenant
-        assert tpl.status == TemplateStatus.DRAFT
+        assert tpl.status == TemplateStatus.APPROVED
+        assert tpl.needs_sync is False
 
     def test_list_filters_by_platform(self, api_client, tenant_user):
         """GET /sms/v1/templates/ only returns SMS templates."""
@@ -86,13 +87,15 @@ class TestSMSTemplateViewSet:
 @pytest.mark.django_db
 class TestTelegramTemplateViewSet:
     def test_create_sets_platform_and_tenant(self, api_client, tenant_user):
-        """POST /telegram/v1/templates/ creates with platform=TELEGRAM."""
+        """POST /telegram/v1/templates/ creates an approved TELEGRAM template."""
         resp = api_client.post("/telegram/v1/templates/", TEMPLATE_PAYLOAD, format="json")
 
         assert resp.status_code == 201
         tpl = WATemplate.objects.get(pk=resp.data["id"])
         assert tpl.platform == "TELEGRAM"
         assert tpl.tenant == tenant_user.tenant
+        assert tpl.status == TemplateStatus.APPROVED
+        assert tpl.needs_sync is False
 
     def test_list_filters_by_platform(self, api_client, tenant_user):
         """GET /telegram/v1/templates/ only returns TELEGRAM templates."""
@@ -109,13 +112,15 @@ class TestTelegramTemplateViewSet:
 @pytest.mark.django_db
 class TestRCSTemplateViewSet:
     def test_create_sets_platform_and_tenant(self, api_client, tenant_user):
-        """POST /rcs/v1/templates/ creates with platform=RCS."""
+        """POST /rcs/v1/templates/ creates an approved RCS template."""
         resp = api_client.post("/rcs/v1/templates/", TEMPLATE_PAYLOAD, format="json")
 
         assert resp.status_code == 201
         tpl = WATemplate.objects.get(pk=resp.data["id"])
         assert tpl.platform == "RCS"
         assert tpl.tenant == tenant_user.tenant
+        assert tpl.status == TemplateStatus.APPROVED
+        assert tpl.needs_sync is False
 
 
 @pytest.mark.django_db

--- a/wa/viewsets/channel_template.py
+++ b/wa/viewsets/channel_template.py
@@ -41,12 +41,12 @@ class _ChannelTemplateMixin:
             from rest_framework.exceptions import ValidationError
 
             raise ValidationError("Could not determine tenant for this request.")
-        
+
         # Non-WhatsApp templates don't need approval - set APPROVED immediately
         # WhatsApp templates need to go through Meta approval process
         initial_status = TemplateStatus.APPROVED if self._channel_platform != "WHATSAPP" else TemplateStatus.DRAFT
         needs_sync = self._channel_platform == "WHATSAPP"  # Only WhatsApp templates need BSP sync
-        
+
         template = serializer.save(
             platform=self._channel_platform,
             tenant=tenant_user.tenant,

--- a/wa/viewsets/channel_template.py
+++ b/wa/viewsets/channel_template.py
@@ -41,11 +41,17 @@ class _ChannelTemplateMixin:
             from rest_framework.exceptions import ValidationError
 
             raise ValidationError("Could not determine tenant for this request.")
+        
+        # Non-WhatsApp templates don't need approval - set APPROVED immediately
+        # WhatsApp templates need to go through Meta approval process
+        initial_status = TemplateStatus.APPROVED if self._channel_platform != "WHATSAPP" else TemplateStatus.DRAFT
+        needs_sync = self._channel_platform == "WHATSAPP"  # Only WhatsApp templates need BSP sync
+        
         template = serializer.save(
             platform=self._channel_platform,
             tenant=tenant_user.tenant,
-            status=TemplateStatus.DRAFT,
-            needs_sync=True,
+            status=initial_status,
+            needs_sync=needs_sync,
         )
         return Response(WATemplateV2Serializer(template).data, status=drf_status.HTTP_201_CREATED)
 


### PR DESCRIPTION
This PR contains Kuwar's original PR 139 changes plus the follow-up fixes required by review because direct push to the original fork branch was not permitted. Key fix areas: non-WA template status tests, shared keyboard builder reuse, byte-safe callback truncation, media+buttons reply_markup support, focused tests, and docs. Focused validation result: 50 passed using: pytest telegram/tests/test_send_message.py telegram/tests/test_keyboard_builder.py wa/tests/test_channel_templates.py -q