### PR TITLE
fix(telegram): enforce media template contract for IMAGE/VIDEO/DOCUMENT

### DIFF
--- a/wa/tests/test_channel_templates.py
+++ b/wa/tests/test_channel_templates.py
@@ -124,6 +124,101 @@ class TestRCSTemplateViewSet:
 
 
 @pytest.mark.django_db
+class TestTelegramMediaTemplates:
+    """Verify the Telegram media-template contract (Issue #143).
+
+    Telegram templates use URL-based media via ``example_media_url``.
+    File upload (tenant_media / media_handle) is not supported.
+    """
+
+    MEDIA_URL = "https://example.com/sample.jpg"
+
+    def test_image_template_with_media_url_accepted(self, api_client):
+        """POST IMAGE template with example_media_url → 201, url persisted."""
+        payload = {
+            "name": "tg_img_tpl",
+            "element_name": "tg_img_tpl",
+            "content": "See the image",
+            "language_code": "en",
+            "category": "MARKETING",
+            "template_type": "IMAGE",
+            "example_media_url": self.MEDIA_URL,
+        }
+        resp = api_client.post("/telegram/v1/templates/", payload, format="json")
+        assert resp.status_code == 201
+        assert resp.data["example_media_url"] == self.MEDIA_URL
+        assert resp.data["template_type"] == "IMAGE"
+
+    def test_image_template_without_media_url_rejected(self, api_client):
+        """POST IMAGE template without example_media_url → 400 with explicit error."""
+        payload = {
+            "name": "tg_img_nurl",
+            "element_name": "tg_img_nurl",
+            "content": "No URL provided",
+            "language_code": "en",
+            "category": "MARKETING",
+            "template_type": "IMAGE",
+        }
+        resp = api_client.post("/telegram/v1/templates/", payload, format="json")
+        assert resp.status_code == 400
+        assert "example_media_url" in resp.data
+
+    def test_video_template_without_media_url_rejected(self, api_client):
+        """POST VIDEO template without example_media_url → 400."""
+        payload = {
+            "name": "tg_vid_nurl",
+            "element_name": "tg_vid_nurl",
+            "content": "No URL provided",
+            "language_code": "en",
+            "category": "MARKETING",
+            "template_type": "VIDEO",
+        }
+        resp = api_client.post("/telegram/v1/templates/", payload, format="json")
+        assert resp.status_code == 400
+        assert "example_media_url" in resp.data
+
+    def test_document_template_with_media_url_accepted(self, api_client):
+        """POST DOCUMENT template with example_media_url → 201."""
+        payload = {
+            "name": "tg_doc_tpl",
+            "element_name": "tg_doc_tpl",
+            "content": "See the document",
+            "language_code": "en",
+            "category": "UTILITY",
+            "template_type": "DOCUMENT",
+            "example_media_url": "https://example.com/sample.pdf",
+        }
+        resp = api_client.post("/telegram/v1/templates/", payload, format="json")
+        assert resp.status_code == 201
+        assert resp.data["example_media_url"] == "https://example.com/sample.pdf"
+
+    def test_types_returns_only_telegram_applicable(self, api_client):
+        """GET /telegram/v1/templates/types/ returns only TEXT, IMAGE, VIDEO, DOCUMENT."""
+        resp = api_client.get("/telegram/v1/templates/types/")
+        assert resp.status_code == 200
+        values = {entry["value"] for entry in resp.data}
+        assert values == {"TEXT", "IMAGE", "VIDEO", "DOCUMENT"}
+        # WA-specific types must not be present
+        assert "CAROUSEL" not in values
+        assert "CATALOG" not in values
+        assert "PRODUCT" not in values
+        assert "ORDER_DETAILS" not in values
+
+    def test_text_template_creates_without_media_url(self, api_client):
+        """TEXT templates need no media URL."""
+        payload = {
+            "name": "tg_text_ok",
+            "element_name": "tg_text_ok",
+            "content": "Hello world",
+            "language_code": "en",
+            "category": "UTILITY",
+            "template_type": "TEXT",
+        }
+        resp = api_client.post("/telegram/v1/templates/", payload, format="json")
+        assert resp.status_code == 201
+
+
+@pytest.mark.django_db
 class TestChannelTemplateIsolation:
     def test_cross_tenant_template_not_visible(self, user, tenant_user):
         """Templates from tenant A are not visible to tenant B."""

--- a/wa/viewsets/channel_template.py
+++ b/wa/viewsets/channel_template.py
@@ -1,6 +1,7 @@
 """Channel-scoped template viewsets that filter WATemplate by platform."""
 
 from rest_framework import status as drf_status
+from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from wa.models import TemplateStatus, WATemplate
@@ -12,6 +13,7 @@ class _ChannelTemplateMixin:
     """Mixin to scope WATemplate queryset to a specific platform."""
 
     _channel_platform: str = ""
+    _MEDIA_TEMPLATE_TYPES = {"IMAGE", "VIDEO", "DOCUMENT"}
 
     def get_queryset(self):
         user = self.request.user
@@ -42,6 +44,20 @@ class _ChannelTemplateMixin:
 
             raise ValidationError("Could not determine tenant for this request.")
 
+        # For non-WA channels, media types (IMAGE/VIDEO/DOCUMENT) require example_media_url.
+        # Telegram (and other channels) use URL-based media references — file upload is not supported.
+        template_type = serializer.validated_data.get("template_type", "")
+        if (
+            self._channel_platform != "WHATSAPP"
+            and template_type in self._MEDIA_TEMPLATE_TYPES
+            and not serializer.validated_data.get("example_media_url")
+        ):
+            from rest_framework.exceptions import ValidationError as DRFValidationError
+
+            raise DRFValidationError(
+                {"example_media_url": f"example_media_url is required for {template_type} templates."}
+            )
+
         # Non-WhatsApp templates don't need approval - set APPROVED immediately
         # WhatsApp templates need to go through Meta approval process
         initial_status = TemplateStatus.APPROVED if self._channel_platform != "WHATSAPP" else TemplateStatus.DRAFT
@@ -66,6 +82,22 @@ class TelegramTemplateViewSet(_ChannelTemplateMixin, WATemplateV2ViewSet):
     """Telegram-scoped template API."""
 
     _channel_platform = "TELEGRAM"
+
+    # Only these types are supported by the Telegram Bot API.
+    # WA-specific types (CAROUSEL, CATALOG, PRODUCT, ORDER_DETAILS, LOCATION) are excluded.
+    _TELEGRAM_TYPES = {"TEXT", "IMAGE", "VIDEO", "DOCUMENT"}
+
+    @action(detail=False, methods=["get"], url_path="types")
+    def types(self, request):
+        """Return only Telegram-applicable template types."""
+        from wa.models import TemplateType
+
+        result = [
+            {"value": value, "label": label, "enabled": True}
+            for value, label in TemplateType.choices
+            if value in self._TELEGRAM_TYPES
+        ]
+        return Response(result)
 
 
 class RCSTemplateViewSet(_ChannelTemplateMixin, WATemplateV2ViewSet):


### PR DESCRIPTION
## Summary
- enforce xample_media_url for non-WA media templates (IMAGE/VIDEO/DOCUMENT)
- narrow Telegram /templates/types/ to supported values: TEXT, IMAGE, VIDEO, DOCUMENT
- add tests for acceptance/rejection and types endpoint contract

## Why
Issue #143 reported ambiguity between advertised Telegram media template types and creation behavior.

## Validation
- pytest wa/tests/test_channel_templates.py -v (12 passed)
- uff check wa/viewsets/channel_template.py wa/tests/test_channel_templates.py (passed)
- Full local telegram suite is blocked by stale local 	est_server DB lock, while PR CI checks are green.
