### PR TITLE
fix: broadcast total_messages falls back to recipient_count for QUEUED/SCHEDULED broadcasts

### DIFF
--- a/broadcast/serializers.py
+++ b/broadcast/serializers.py
@@ -67,7 +67,21 @@ class BroadcastSerializer(BaseSerializer):
         return getattr(obj, "blocked_count", 0)
 
     def get_total_messages(self, obj):
-        return getattr(obj, "total_messages", 0)
+        # Prefer annotated value from queryset; this is used in list/retrieve views.
+        annotated_total = getattr(obj, "total_messages", None)
+        if annotated_total is not None:
+            return annotated_total
+
+        # For freshly created queued/scheduled broadcasts, message rows may not
+        # exist yet because dispatch is asynchronous. Expose recipient count as
+        # the expected total to avoid reporting a false zero immediately after create.
+        if obj.status in {BroadcastStatusChoices.QUEUED, BroadcastStatusChoices.SCHEDULED}:
+            created_rows = obj.broadcasts.count()
+            if created_rows > 0:
+                return created_rows
+            return obj.recipients.count()
+
+        return obj.broadcasts.count()
 
     def get_success_count(self, obj):
         return getattr(obj, "success_count", 0)

--- a/broadcast/signals.py
+++ b/broadcast/signals.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from django.db import transaction
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -242,19 +243,27 @@ def _schedule_broadcast_task(broadcast_instance, current_time):
             logger.error("[CREDIT ERROR] %s", error_msg)
             # Don't fail the broadcast for non-balance errors, just log
 
-        # Schedule the Celery task only after credits are secured
-        task_result = setup_broadcast_task.apply_async(args=[broadcast_instance.id], countdown=countdown)
-
-        # Save task_id
-        broadcast_instance.task_id = task_result.id
-        broadcast_instance.reason_for_cancellation = None
-        broadcast_instance.status = BroadcastStatusChoices.SCHEDULED
-        # Prevent infinite recursion by updating only specific fields
+        # Persist SCHEDULED state first; enqueue is done on transaction commit
+        # so workers never observe partially committed broadcast state.
         Broadcast.objects.filter(pk=broadcast_instance.pk).update(
-            task_id=task_result.id, reason_for_cancellation=None, status=BroadcastStatusChoices.SCHEDULED
+            task_id=None, reason_for_cancellation=None, status=BroadcastStatusChoices.SCHEDULED
         )
 
-        logger.debug(f"[TASK SCHEDULED] Broadcast {broadcast_instance.id}: Task {task_result.id} in {countdown}s")
+        broadcast_id = broadcast_instance.pk
+
+        def _enqueue_broadcast_task():
+            try:
+                task_result = setup_broadcast_task.apply_async(args=[broadcast_id], countdown=countdown)
+                Broadcast.objects.filter(pk=broadcast_id).update(task_id=task_result.id)
+                logger.debug(f"[TASK SCHEDULED] Broadcast {broadcast_id}: Task {task_result.id} in {countdown}s")
+            except Exception as enqueue_error:
+                error_msg = f"Failed to schedule broadcast task: {str(enqueue_error)}"
+                logger.error("[TASK ERROR] %s", error_msg)
+                Broadcast.objects.filter(pk=broadcast_id).update(
+                    status=BroadcastStatusChoices.FAILED, reason_for_cancellation=error_msg
+                )
+
+        transaction.on_commit(_enqueue_broadcast_task)
 
     except Exception as e:
         error_msg = f"Failed to schedule broadcast task: {str(e)}"

--- a/broadcast/tests/test_scheduled_broadcast.py
+++ b/broadcast/tests/test_scheduled_broadcast.py
@@ -223,6 +223,61 @@ class TestBroadcastTotalMessagesSerializer:
         assert "error" in result
 
 
+@pytest.mark.django_db
+class TestSignalSchedulingOnCommit:
+    def test_schedule_enqueue_happens_on_commit(self, tenant, user, contact, monkeypatch):
+        from broadcast import signals
+
+        bc = Broadcast.objects.create(
+            tenant=tenant,
+            name="On Commit Queue",
+            status=BroadcastStatusChoices.QUEUED,
+            platform=BroadcastPlatformChoices.TELEGRAM,
+            template_number_id=None,
+            created_by=user,
+            scheduled_time=timezone.now() + timezone.timedelta(minutes=10),
+        )
+        bc.recipients.add(contact)
+
+        # Bypass pricing/credit side effects for this scheduling unit test.
+        monkeypatch.setattr(
+            signals.BroadcastCreditManager,
+            "deduct_credits_for_broadcast",
+            lambda self, broadcast: None,
+        )
+
+        queued_callbacks = []
+        monkeypatch.setattr(signals.transaction, "on_commit", lambda fn: queued_callbacks.append(fn))
+
+        apply_calls = []
+
+        class _FakeTaskResult:
+            id = "commit-task-id"
+
+        from broadcast.tasks import setup_broadcast_task
+
+        monkeypatch.setattr(
+            setup_broadcast_task,
+            "apply_async",
+            lambda args, countdown: apply_calls.append((args, countdown)) or _FakeTaskResult(),
+        )
+
+        signals._schedule_broadcast_task(bc, timezone.now())
+
+        bc.refresh_from_db()
+        assert bc.status == BroadcastStatusChoices.SCHEDULED
+        assert bc.task_id is None
+        assert apply_calls == []
+        assert len(queued_callbacks) == 1
+
+        queued_callbacks[0]()
+
+        bc.refresh_from_db()
+        assert apply_calls
+        assert apply_calls[0][0] == [bc.pk]
+        assert bc.task_id == "commit-task-id"
+
+
 # ---------------------------------------------------------------------------
 # Cancel action tests (#102)
 # ---------------------------------------------------------------------------

--- a/broadcast/tests/test_scheduled_broadcast.py
+++ b/broadcast/tests/test_scheduled_broadcast.py
@@ -14,6 +14,7 @@ from broadcast.models import (
     BroadcastStatusChoices,
     MessageStatusChoices,
 )
+from broadcast.serializers import BroadcastSerializer
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -178,6 +179,44 @@ class TestSetupBroadcastTask:
 
     def test_nonexistent_broadcast(self):
         """Task handles missing broadcast gracefully."""
+
+
+@pytest.mark.django_db
+class TestBroadcastTotalMessagesSerializer:
+    def test_queued_broadcast_falls_back_to_recipient_count(self, tenant, user, contact):
+        """Queued/Scheduled broadcast should not report false zero before async rows are created."""
+        bc = Broadcast.objects.create(
+            tenant=tenant,
+            name="Queued Telegram",
+            status=BroadcastStatusChoices.QUEUED,
+            platform=BroadcastPlatformChoices.TELEGRAM,
+            created_by=user,
+        )
+        bc.recipients.add(contact)
+
+        data = BroadcastSerializer(instance=bc).data
+        assert data["total_messages"] == 1
+
+    def test_non_queued_broadcast_uses_created_message_rows(self, tenant, user, contact):
+        """For non-queued states, total_messages reflects actual BroadcastMessage rows."""
+        bc = Broadcast.objects.create(
+            tenant=tenant,
+            name="Sending Telegram",
+            status=BroadcastStatusChoices.SENDING,
+            platform=BroadcastPlatformChoices.TELEGRAM,
+            created_by=user,
+        )
+        bc.recipients.add(contact)
+
+        BroadcastMessage.objects.create(
+            broadcast=bc,
+            contact=contact,
+            status=MessageStatusChoices.PENDING,
+            created_by=user,
+        )
+
+        data = BroadcastSerializer(instance=bc).data
+        assert data["total_messages"] == 1
         from broadcast.tasks import setup_broadcast_task
 
         result = setup_broadcast_task(999999)

--- a/broadcast/tests/test_scheduled_broadcast.py
+++ b/broadcast/tests/test_scheduled_broadcast.py
@@ -179,6 +179,10 @@ class TestSetupBroadcastTask:
 
     def test_nonexistent_broadcast(self):
         """Task handles missing broadcast gracefully."""
+        from broadcast.tasks import setup_broadcast_task
+
+        result = setup_broadcast_task(999999)
+        assert "error" in result
 
 
 @pytest.mark.django_db
@@ -217,10 +221,6 @@ class TestBroadcastTotalMessagesSerializer:
 
         data = BroadcastSerializer(instance=bc).data
         assert data["total_messages"] == 1
-        from broadcast.tasks import setup_broadcast_task
-
-        result = setup_broadcast_task(999999)
-        assert "error" in result
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

When a broadcast is newly created, BroadcastMessage rows are populated **asynchronously** by Celery. The BroadcastSerializer.get_total_messages method was returning 