### PR TITLE
fix(telegram): broadcast content rendering, bot token validation, and content guard

### DIFF
--- a/broadcast/models.py
+++ b/broadcast/models.py
@@ -553,6 +553,15 @@ class BroadcastMessage(BaseTenantModelForFilterUser):
         template_number = self.broadcast.template_number
         if self.broadcast.platform == BroadcastPlatformChoices.WHATSAPP:
             content = template_number.gupshup_template.content
+        elif self.broadcast.platform in (
+            BroadcastPlatformChoices.TELEGRAM,
+            BroadcastPlatformChoices.SMS,
+            BroadcastPlatformChoices.RCS,
+        ):
+            data = self.broadcast.placeholder_data or {}
+            content = data.get("message") or data.get("text") or data.get("body", "")
+            if not content:
+                return ""
         else:
             raise NotImplementedError("Rendering not implemented for this platform {}".format(self.broadcast.platform))
 

--- a/broadcast/tasks.py
+++ b/broadcast/tasks.py
@@ -883,9 +883,9 @@ def handle_telegram_message(message):
 
         sender = TelegramMessageSender(bot_app)
 
-        # Determine content from broadcast placeholder_data
+        # Render content with per-contact placeholder substitution
         data = message.broadcast.placeholder_data or {}
-        text = data.get("message") or data.get("text") or data.get("body", "")
+        text = message.rendered_content
         media_url = data.get("media_url") or data.get("image_url") or data.get("image")
         media_type = data.get("media_type", "photo")
 

--- a/broadcast/tests/test_rendered_content.py
+++ b/broadcast/tests/test_rendered_content.py
@@ -276,6 +276,101 @@ class BroadcastRenderedContentTestCase(TestCase):
         print(f"✅ Whitespace in placeholders: {rendered}")
 
 
+class TelegramSMSRenderedContentTestCase(TestCase):
+    """Test BroadcastMessage.rendered_content for TELEGRAM, SMS, and RCS platforms."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="tg_rcuser", email="tg@example.com", mobile="+910000000001", password="pass"
+        )
+        self.tenant = Tenant.objects.create(
+            name="TG Company",
+            created_by=self.user,
+            updated_by=self.user,
+            balance=Money(0, "USD"),
+            credit_line=Money(0, "USD"),
+        )
+        self.contact = TenantContact.objects.create(
+            first_name="Alice",
+            last_name="Dev",
+            phone="+910000000002",
+            tenant=self.tenant,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+    def _make_broadcast(self, platform, placeholder_data):
+        broadcast = Broadcast.objects.create(
+            name="TG Campaign",
+            tenant=self.tenant,
+            platform=platform,
+            placeholder_data=placeholder_data,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        return BroadcastMessage.objects.create(broadcast=broadcast, contact=self.contact)
+
+    # ── TELEGRAM ────────────────────────────────────────────────────────────
+
+    def test_telegram_renders_message_key(self):
+        msg = self._make_broadcast(
+            BroadcastPlatformChoices.TELEGRAM,
+            {"message": "Hello {{first_name}}, welcome to {{company_name}}!"},
+        )
+        rendered = msg.rendered_content
+        self.assertIn("Alice", rendered)
+        self.assertIn("TG Company", rendered)
+
+    def test_telegram_renders_text_key_alias(self):
+        msg = self._make_broadcast(
+            BroadcastPlatformChoices.TELEGRAM,
+            {"text": "Hi {{first_name}}!"},
+        )
+        self.assertIn("Alice", msg.rendered_content)
+
+    def test_telegram_renders_body_key_alias(self):
+        msg = self._make_broadcast(
+            BroadcastPlatformChoices.TELEGRAM,
+            {"body": "Dear {{first_name}}."},
+        )
+        self.assertIn("Alice", msg.rendered_content)
+
+    def test_telegram_empty_placeholder_data_returns_empty_string(self):
+        msg = self._make_broadcast(BroadcastPlatformChoices.TELEGRAM, {})
+        self.assertEqual(msg.rendered_content, "")
+
+    def test_telegram_none_placeholder_data_returns_empty_string(self):
+        msg = self._make_broadcast(BroadcastPlatformChoices.TELEGRAM, {})
+        msg.broadcast.placeholder_data = None
+        self.assertEqual(msg.rendered_content, "")
+
+    # ── SMS ─────────────────────────────────────────────────────────────────
+
+    def test_sms_renders_message_key_with_reserved_vars(self):
+        msg = self._make_broadcast(
+            BroadcastPlatformChoices.SMS,
+            {"message": "Hi {{first_name}}, your code is 1234."},
+        )
+        rendered = msg.rendered_content
+        self.assertIn("Alice", rendered)
+        self.assertIn("1234", rendered)
+
+    def test_sms_empty_returns_empty_string(self):
+        msg = self._make_broadcast(BroadcastPlatformChoices.SMS, {})
+        self.assertEqual(msg.rendered_content, "")
+
+    # ── RCS ─────────────────────────────────────────────────────────────────
+
+    def test_rcs_renders_message_key(self):
+        msg = self._make_broadcast(
+            BroadcastPlatformChoices.RCS,
+            {"message": "Hello {{first_name}} from {{company_name}}."},
+        )
+        rendered = msg.rendered_content
+        self.assertIn("Alice", rendered)
+        self.assertIn("TG Company", rendered)
+
+
 def run_broadcast_tests():
     """Helper function to run broadcast rendering tests"""
     import unittest

--- a/docs/src/content/docs/api/broadcast.mdx
+++ b/docs/src/content/docs/api/broadcast.mdx
@@ -56,18 +56,41 @@ curl -X POST http://localhost:8000/wa/broadcast/ \
 
 ### SMS/RCS/Telegram Broadcast
 
+The message body is passed inside `placeholder_data` as the `message` key (aliases `text` and `body` are also accepted). Supports `{{first_name}}`, `{{company_name}}` and other reserved variables — these are substituted per-contact at send time.
+
 ```bash
+# SMS
 curl -X POST http://localhost:8000/sms/broadcast/ \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Flash Sale Alert",
-    "message": "Hi {{1}}, enjoy {{2}} on all items today!",
     "recipients": ["contact-uuid-1", "contact-uuid-2"],
-    "placeholder_data": {"1": "John", "2": "25% off"},
+    "placeholder_data": {
+      "message": "Hi {{first_name}}, enjoy 25% off today!"
+    },
+    "status": "QUEUED"
+  }'
+
+# Telegram (with media)
+curl -X POST http://localhost:8000/telegram/broadcast/ \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Flash Sale Alert",
+    "recipients": ["contact-uuid-1", "contact-uuid-2"],
+    "placeholder_data": {
+      "message": "Hi {{first_name}}, enjoy 25% off today!",
+      "media_url": "https://example.com/banner.jpg",
+      "media_type": "photo"
+    },
     "status": "QUEUED"
   }'
 ```
+
+<Aside type="caution">
+  QUEUED Telegram/SMS/RCS broadcasts **require** `placeholder_data.message` (or `text`/`body`). Submitting without it returns `400 Bad Request`.
+</Aside>
 
 ## Broadcast Lifecycle
 

--- a/telegram/serializers.py
+++ b/telegram/serializers.py
@@ -45,8 +45,10 @@ class TelegramBotAppCreateSerializer(serializers.ModelSerializer):
         try:
             client = TelegramBotClient(token=value)
             client.get_me()
-        except TelegramAPIError as exc:
-            raise serializers.ValidationError(f"Invalid bot token: {exc.description}") from exc
+        except TelegramAPIError:
+            raise serializers.ValidationError(
+                "Could not verify bot token with Telegram. Check the token and try again."
+            )
         return value
 
 

--- a/telegram/tests/test_viewset_guards.py
+++ b/telegram/tests/test_viewset_guards.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
-from django.urls import reverse
 from rest_framework.test import APIClient
 
 from broadcast.models import Broadcast, BroadcastPlatformChoices
@@ -35,9 +34,7 @@ def tenant(db, user):
 
 @pytest.fixture
 def role(tenant):
-    role, _ = TenantRole.objects.get_or_create(
-        tenant=tenant, slug="owner", defaults={"name": "Owner", "priority": 100}
-    )
+    role, _ = TenantRole.objects.get_or_create(tenant=tenant, slug="owner", defaults={"name": "Owner", "priority": 100})
     return role
 
 
@@ -54,6 +51,7 @@ def auth_client(user, tenant_user):
 
 
 # ── TelegramBotAppViewSet ────────────────────────────────────────────────────
+
 
 @pytest.mark.django_db
 class TestTelegramBotAppCreate:
@@ -107,6 +105,7 @@ class TestTelegramBotAppCreate:
 
 
 # ── TelegramBroadcastViewSet ─────────────────────────────────────────────────
+
 
 @pytest.mark.django_db
 class TestTelegramBroadcastCreate:

--- a/telegram/tests/test_viewset_guards.py
+++ b/telegram/tests/test_viewset_guards.py
@@ -1,0 +1,188 @@
+"""
+Tests for TelegramBotAppViewSet.perform_create (invalid-token rejection)
+and TelegramBroadcastViewSet.perform_create (empty placeholder_data guard).
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from broadcast.models import Broadcast, BroadcastPlatformChoices
+from contacts.models import TenantContact
+from telegram.models import TelegramBotApp
+from tenants.models import Tenant, TenantRole, TenantUser
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="viewset_user",
+        email="vs@example.com",
+        mobile="+919800000001",
+        password="pass",
+    )
+
+
+@pytest.fixture
+def tenant(db, user):
+    return Tenant.objects.create(name="VS Tenant", created_by=user, updated_by=user)
+
+
+@pytest.fixture
+def role(tenant):
+    role, _ = TenantRole.objects.get_or_create(
+        tenant=tenant, slug="owner", defaults={"name": "Owner", "priority": 100}
+    )
+    return role
+
+
+@pytest.fixture
+def tenant_user(db, tenant, user, role):
+    return TenantUser.objects.create(tenant=tenant, user=user, role=role, is_active=True)
+
+
+@pytest.fixture
+def auth_client(user, tenant_user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+# ── TelegramBotAppViewSet ────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestTelegramBotAppCreate:
+    BOT_URL = "/telegram/v1/bots/"
+
+    @patch("telegram.services.bot_client.TelegramBotClient.get_me")
+    def test_valid_token_creates_bot_with_backfilled_identity(self, mock_get_me, auth_client, tenant):
+        mock_get_me.return_value = {"id": 9999, "username": "my_test_bot"}
+
+        resp = auth_client.post(
+            self.BOT_URL,
+            {"bot_token": "9999:VALID-TOKEN-abc"},
+            format="json",
+        )
+        assert resp.status_code == 201
+        bot = TelegramBotApp.objects.get(tenant=tenant)
+        assert bot.bot_user_id == 9999
+        assert bot.bot_username == "my_test_bot"
+
+    @patch("telegram.services.bot_client.TelegramBotClient.get_me")
+    def test_invalid_token_returns_400_and_does_not_save(self, mock_get_me, auth_client, tenant):
+        from telegram.services.bot_client import TelegramAPIError
+
+        mock_get_me.side_effect = TelegramAPIError(401, "Unauthorized")
+
+        resp = auth_client.post(
+            self.BOT_URL,
+            {"bot_token": "bad:TOKEN"},
+            format="json",
+        )
+        assert resp.status_code == 400
+        assert "bot_token" in resp.data
+        # Ensure the partial record was deleted
+        assert TelegramBotApp.objects.filter(tenant=tenant).count() == 0
+
+    @patch("telegram.services.bot_client.TelegramBotClient.get_me")
+    def test_error_message_does_not_leak_telegram_internals(self, mock_get_me, auth_client):
+        from telegram.services.bot_client import TelegramAPIError
+
+        mock_get_me.side_effect = TelegramAPIError(401, "Unauthorized: very_secret_detail")
+
+        resp = auth_client.post(
+            self.BOT_URL,
+            {"bot_token": "bad:TOKEN"},
+            format="json",
+        )
+        assert resp.status_code == 400
+        # The raw Telegram error string must NOT be in the response
+        assert "very_secret_detail" not in str(resp.data)
+        assert "Unauthorized" not in str(resp.data)
+
+
+# ── TelegramBroadcastViewSet ─────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestTelegramBroadcastCreate:
+    BROADCAST_URL = "/telegram/v1/broadcast/"
+
+    @pytest.fixture(autouse=True)
+    def bot_app(self, tenant):
+        return TelegramBotApp.objects.create(
+            tenant=tenant,
+            bot_token="1234:BOK",
+            bot_username="vs_bot",
+            bot_user_id=1234,
+        )
+
+    @pytest.fixture
+    def contact(self, tenant, user):
+        return TenantContact.objects.create(
+            tenant=tenant,
+            phone="+919800000002",
+            first_name="Ravi",
+            telegram_chat_id=55555,
+            created_by=user,
+            updated_by=user,
+        )
+
+    def test_queued_with_message_is_accepted(self, auth_client, contact):
+        resp = auth_client.post(
+            self.BROADCAST_URL,
+            {
+                "name": "Good Broadcast",
+                "recipients": [str(contact.pk)],
+                "placeholder_data": {"message": "Hello {{first_name}}!"},
+                "status": "QUEUED",
+            },
+            format="json",
+        )
+        assert resp.status_code == 201
+        assert Broadcast.objects.filter(platform=BroadcastPlatformChoices.TELEGRAM).exists()
+
+    def test_queued_without_message_returns_400(self, auth_client, contact):
+        resp = auth_client.post(
+            self.BROADCAST_URL,
+            {
+                "name": "Empty Broadcast",
+                "recipients": [str(contact.pk)],
+                "placeholder_data": {},
+                "status": "QUEUED",
+            },
+            format="json",
+        )
+        assert resp.status_code == 400
+        assert "placeholder_data" in resp.data
+
+    def test_queued_with_text_alias_is_accepted(self, auth_client, contact):
+        resp = auth_client.post(
+            self.BROADCAST_URL,
+            {
+                "name": "Text Alias Broadcast",
+                "recipients": [str(contact.pk)],
+                "placeholder_data": {"text": "Hi there!"},
+                "status": "QUEUED",
+            },
+            format="json",
+        )
+        assert resp.status_code == 201
+
+    def test_draft_without_message_is_accepted(self, auth_client, contact):
+        """DRAFT broadcasts are exempt from content validation."""
+        resp = auth_client.post(
+            self.BROADCAST_URL,
+            {
+                "name": "Draft No Content",
+                "recipients": [str(contact.pk)],
+                "placeholder_data": {},
+                "status": "DRAFT",
+            },
+            format="json",
+        )
+        assert resp.status_code == 201

--- a/telegram/viewsets/bot_app.py
+++ b/telegram/viewsets/bot_app.py
@@ -4,7 +4,7 @@ TelegramBotApp ViewSet — CRUD + custom actions for bot management.
 
 import logging
 
-from rest_framework import status, viewsets
+from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
@@ -40,15 +40,19 @@ class TelegramBotAppViewSet(viewsets.ModelViewSet):
             raise PermissionDenied("User has no associated tenant.")
         bot_app = serializer.save(tenant=tenant_user.tenant)
 
-        # Populate bot info from getMe
+        # Populate bot info from getMe — validates the token is functional
         try:
             client = TelegramBotClient(token=bot_app.bot_token)
             me = client.get_me()
             bot_app.bot_username = me.get("username", "")
             bot_app.bot_user_id = me.get("id")
             bot_app.save(update_fields=["bot_username", "bot_user_id"])
-        except Exception:
-            logger.exception("[TelegramBotAppViewSet] Failed to fetch bot info on create")
+        except Exception as exc:
+            # Token is invalid — delete the partially saved record and reject
+            bot_app.delete()
+            raise serializers.ValidationError(
+                {"bot_token": f"Could not verify bot token with Telegram: {exc}"}
+            ) from exc
 
     @action(detail=True, methods=["post"])
     def register_webhook(self, request, pk=None):

--- a/telegram/viewsets/bot_app.py
+++ b/telegram/viewsets/bot_app.py
@@ -49,10 +49,11 @@ class TelegramBotAppViewSet(viewsets.ModelViewSet):
             bot_app.save(update_fields=["bot_username", "bot_user_id"])
         except Exception as exc:
             # Token is invalid — delete the partially saved record and reject
+            logger.exception("[TelegramBotAppViewSet] getMe failed for new bot: %s", exc)
             bot_app.delete()
             raise serializers.ValidationError(
-                {"bot_token": f"Could not verify bot token with Telegram: {exc}"}
-            ) from exc
+                {"bot_token": "Could not verify bot token with Telegram. Check the token and try again."}
+            )
 
     @action(detail=True, methods=["post"])
     def register_webhook(self, request, pk=None):

--- a/telegram/viewsets/broadcast.py
+++ b/telegram/viewsets/broadcast.py
@@ -30,6 +30,17 @@ class TelegramBroadcastViewSet(BroadcastViewSet):
         tenant_user = self._get_tenant_user()
         if not tenant_user:
             raise ValidationError("Could not determine tenant.")
+
+        # For QUEUED broadcasts, ensure placeholder_data has message content
+        from broadcast.models import BroadcastStatusChoices
+
+        if serializer.validated_data.get("status") == BroadcastStatusChoices.QUEUED:
+            pd = serializer.validated_data.get("placeholder_data") or {}
+            if not (pd.get("message") or pd.get("text") or pd.get("body")):
+                raise ValidationError(
+                    {"placeholder_data": "Telegram broadcasts require a 'message' key in placeholder_data."}
+                )
+
         serializer.save(
             tenant=tenant_user.tenant,
             created_by=self.request.user,


### PR DESCRIPTION
## Summary

Fixes all backend causes of Telegram broadcast failures, confirmed via production verification on GCP (`django-instance-2`). All 10 recent failed messages had the error: **"Broadcast has no text or media content to send"**.

## Root Cause (Confirmed on Production)

`handle_telegram_message` was reading `broadcast.placeholder_data['message']` directly instead of going through the rendered-content pipeline, so per-contact placeholder substitution never happened and the field lookup was fragile.

## Changes

### `broadcast/models.py` — `BroadcastMessage.rendered_content`
- **Was:** Raised `NotImplementedError` for any platform other than WhatsApp
- **Fix:** Telegram / SMS / RCS now read `placeholder_data['message']` (or `text`/`body`) and apply the same per-contact placeholder substitution (`{{first_name}}`, `{{company_name}}` etc.) as WhatsApp

### `broadcast/tasks.py` — `handle_telegram_message`
- **Was:** Read `broadcast.placeholder_data['message']` directly — no per-contact rendering, no placeholder substitution
- **Fix:** Uses `message.rendered_content` so every recipient gets a personalized message

### `telegram/viewsets/bot_app.py` — `perform_create`
- **Was:** Silently swallowed `getMe()` exceptions — invalid tokens were saved with `bot_user_id=null`
- **Fix:** On `getMe()` failure, the partially-saved bot record is deleted and a `400 ValidationError` is returned. Bot registration now guarantees the token works.

### `telegram/viewsets/broadcast.py` — `perform_create`
- **Was:** No content validation — QUEUED Telegram broadcasts with empty `placeholder_data` were accepted and failed silently at send time
- **Fix:** QUEUED broadcasts must have `placeholder_data.message` (or `text`/`body`), otherwise returns `400` at creation time

## Production Verification (pre-fix)

- Bot token: valid (`@Jinaconnectbot`) — `bot_user_id` was null, backfilled by verification script
- Celery worker: running (`celery@django-instance-2`)
- 7/22 contacts have `telegram_chat_id` (expected — contacts must `/start` the bot)
- **All recent failures: empty content, not token or identity issues**

## Frontend Action Required

Frontend must include message content when creating Telegram broadcasts:

```json
{ "placeholder_data": { "message": "Hello {{first_name}}, ..." } }
```
