### PR TITLE
feat(voice): B1-B4 SIP wizard unblockers — Asterisk health, RBAC, mutex, webhook probe

### DIFF
--- a/docs/src/content/docs/deployment/asterisk.mdx
+++ b/docs/src/content/docs/deployment/asterisk.mdx
@@ -1,0 +1,302 @@
+---
+title: Asterisk + chan_pjsip
+description: Deploy Asterisk 20 LTS with chan_pjsip + ARI to unblock the SIP voice adapter.
+---
+
+import { Steps, Tabs, TabItem, Aside } from "@astrojs/starlight/components";
+
+The SIP voice adapter (`voice/adapters/sip.py`) writes per-config PJSIP
+endpoint files and originates calls through Asterisk's REST Interface
+(ARI). The adapter alone does not place calls — Asterisk has to be
+running on the same box as Django (or reachable on a private network)
+and configured to load `chan_pjsip`, expose ARI on the loopback, and
+include the writer's drop-in directory.
+
+This page is the runbook for standing that up. The frontend SIP wizard
+flips from greyed → enabled by polling
+`GET /voice/v1/api/ari-health/`, so once Asterisk is up the gallery
+tile becomes available automatically.
+
+## Prerequisites
+
+* A Linux VM with at least 2 vCPU / 4 GB RAM (sized for ~50 concurrent
+  call legs; scale horizontally for more).
+* Outbound network access on UDP 5060 to your carrier(s) and inbound
+  UDP 5060 + UDP 10000-20000 from the carrier's published source IPs.
+* Django container can reach the Asterisk box on TCP 8088 (ARI).
+* Carrier-supplied SIP credentials (username, password, realm, proxy).
+
+<Aside type="caution">
+  Never expose ARI (TCP 8088) on a public IP. The REST API has full
+  control of call routing — bind it to `127.0.0.1` or a private subnet.
+</Aside>
+
+## 1. Install Asterisk
+
+<Tabs>
+<TabItem label="Debian / Ubuntu">
+
+```sh
+sudo apt update
+sudo apt install -y asterisk asterisk-mp3 asterisk-modules
+sudo systemctl enable asterisk
+```
+
+</TabItem>
+<TabItem label="Build from source">
+
+The distro packages are typically a major version behind. Build from
+source if you need Asterisk 21+ features (e.g. WebRTC media bridge):
+
+```sh
+sudo apt install -y build-essential libedit-dev libjansson-dev \
+  libsqlite3-dev libssl-dev libxml2-dev libuuid1
+curl -L https://downloads.asterisk.org/pub/telephony/asterisk/asterisk-20-current.tar.gz | tar xz
+cd asterisk-20.*/
+sudo contrib/scripts/install_prereq install
+./configure --with-jansson-bundled
+make menuselect.makeopts
+sudo make install
+sudo make samples
+sudo make config
+```
+
+</TabItem>
+</Tabs>
+
+Confirm the version and that `chan_pjsip` is built in (the default for
+Asterisk 18+):
+
+```sh
+asterisk -V
+sudo asterisk -rx "module show like chan_pjsip"
+```
+
+## 2. Configure ARI
+
+Edit `/etc/asterisk/ari.conf`:
+
+```ini
+[general]
+enabled = yes
+pretty = yes
+
+[jina-voice]
+type = user
+password = REPLACE_ME_WITH_A_LONG_RANDOM_SECRET
+read_only = no
+```
+
+Edit `/etc/asterisk/http.conf` — ARI lives on top of the built-in HTTP
+server. Keep it on loopback only:
+
+```ini
+[general]
+enabled = yes
+bindaddr = 127.0.0.1
+bindport = 8088
+```
+
+Reload:
+
+```sh
+sudo systemctl restart asterisk
+sudo asterisk -rx "ari show status"
+```
+
+You should see `ARI HTTP enabled: Yes` and the `jina-voice` user listed.
+
+## 3. PJSIP skeleton + drop-in directory
+
+`voice/sip_config/pjsip_writer.py` writes one file per
+`VoiceProviderConfig` into `/etc/asterisk/pjsip.d/<config_uuid>.conf`
+(transport + endpoint + auth + registration). The base
+`/etc/asterisk/pjsip.conf` must include that directory and define the
+shared inbound dialplan context that endpoint templates reference:
+
+```ini
+; /etc/asterisk/pjsip.conf
+
+[global]
+type = global
+user_agent = jina-voice
+
+[transport-udp]
+type = transport
+protocol = udp
+bind = 0.0.0.0:5060
+
+[transport-tcp]
+type = transport
+protocol = tcp
+bind = 0.0.0.0:5060
+
+#include pjsip.d/*.conf
+```
+
+And the dialplan context the endpoint files set as their `context=`:
+
+```ini
+; /etc/asterisk/extensions.conf
+
+[jina-voice-inbound]
+exten => _X.,1,NoOp(Inbound call ${EXTEN})
+ same => n,Stasis(jina-voice,inbound,${EXTEN},${CALLERID(num)})
+ same => n,Hangup()
+
+[jina-voice-outbound]
+exten => _X.,1,NoOp(Outbound call ${EXTEN})
+ same => n,Stasis(jina-voice,outbound,${EXTEN})
+ same => n,Hangup()
+```
+
+Reload Asterisk to pick up the writer's drop-in:
+
+```sh
+sudo asterisk -rx "pjsip reload"
+sudo asterisk -rx "dialplan reload"
+```
+
+## 4. RTP port range + firewall
+
+In `/etc/asterisk/rtp.conf`:
+
+```ini
+[general]
+rtpstart = 10000
+rtpend = 20000
+```
+
+On the firewall (GCP / AWS / iptables):
+
+| Port range            | Protocol | Direction | Source                       |
+|-----------------------|----------|-----------|------------------------------|
+| 5060                  | UDP      | Ingress   | Carrier SBC IPs (per vendor) |
+| 5060                  | TCP      | Ingress   | Carrier SBC IPs (TLS-SIP)    |
+| 10000-20000           | UDP      | Ingress   | Carrier SBC IPs              |
+| 8088                  | TCP      | —         | **Closed externally**        |
+
+Each carrier publishes its source IPs:
+
+* **Didlogic** — see your account dashboard
+* **Telnyx** — [telnyx.com/legal/ip-addresses](https://telnyx.com/legal/ip-addresses)
+* **Plivo** — see Plivo console under SIP trunking
+* **Twilio Elastic SIP** — [twilio.com/docs/sip-trunking/ip-addresses](https://www.twilio.com/docs/sip-trunking/ip-addresses)
+
+For GCP, the firewall rules look like:
+
+```sh
+gcloud compute firewall-rules create voice-sip-udp \
+  --network=default --direction=INGRESS --action=ALLOW \
+  --rules=udp:5060,udp:10000-20000 \
+  --source-ranges=<carrier-ip>,...
+
+gcloud compute firewall-rules create voice-sip-tcp \
+  --network=default --direction=INGRESS --action=ALLOW \
+  --rules=tcp:5060 \
+  --source-ranges=<carrier-ip>,...
+```
+
+## 5. Django env vars
+
+Set these in the Django container / systemd unit:
+
+| Variable                  | Example                       |
+|---------------------------|-------------------------------|
+| `ASTERISK_ARI_URL`        | `http://127.0.0.1:8088/`      |
+| `ASTERISK_ARI_USER`       | `jina-voice`                  |
+| `ASTERISK_ARI_PASSWORD`   | (matches `ari.conf`)          |
+| `ASTERISK_ARI_APP_NAME`   | `jina-voice`                  |
+
+The same secrets are referenced by `voice/sip_config/ari_client.py`.
+
+## 6. ARI WebSocket consumer
+
+`voice/sip_config/ari_consumer.py` is a long-running process that opens
+a WebSocket to ARI and translates Stasis events into `VoiceCallEvent`
+rows. It must run alongside the web workers:
+
+<Tabs>
+<TabItem label="systemd">
+
+`/etc/systemd/system/jina-voice-ari.service`:
+
+```ini
+[Unit]
+Description=Jina Voice ARI consumer
+After=network.target asterisk.service
+Requires=asterisk.service
+
+[Service]
+Type=simple
+User=tech
+WorkingDirectory=/home/tech/server-v2
+EnvironmentFile=/etc/jina/env
+ExecStart=/home/tech/server-v2/venv/bin/python manage.py voice_ari_consumer
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now jina-voice-ari
+```
+
+</TabItem>
+<TabItem label="Celery beat watchdog">
+
+If you prefer to keep the process model uniform with the rest of the
+stack, add a Celery beat that ensures the consumer is alive every
+minute. The consumer is idempotent — re-launching when already running
+is a no-op.
+
+</TabItem>
+</Tabs>
+
+## 7. Verify
+
+```sh
+# Asterisk healthy?
+sudo asterisk -rx "core show uptime"
+
+# ARI reachable from Django host?
+curl -u jina-voice:REPLACE_ME http://127.0.0.1:8088/ari/asterisk/info
+
+# Endpoints registered for your VoiceProviderConfig?
+sudo asterisk -rx "pjsip show endpoints"
+```
+
+From any tenant user that has voice enabled, hit the health endpoint:
+
+```sh
+curl -H "Authorization: Token …" https://example.com/voice/v1/api/ari-health/
+```
+
+A 200 response means the SIP gallery tile in the wizard will be
+enabled. A 503 surfaces the reason (`ASTERISK_ARI_URL not set`, auth
+failure, connection refused, …) so the issue is debuggable without
+shelling into the box.
+
+## 8. Smoke test
+
+Provision a `VoiceProviderConfig` with `provider=sip` against your
+carrier, then place a call via the REST API:
+
+```sh
+curl -X POST -H "Authorization: Token …" -H "Content-Type: application/json" \
+  https://example.com/voice/v1/api/calls/initiate/ \
+  -d '{"to_number": "+14155550100", "tts_text": "Hello from Jina."}'
+```
+
+Watch the call hit `RINGING` in:
+
+```sh
+sudo asterisk -rx "core show channels"
+```
+
+If it never leaves `QUEUED` and `ari-health` returns 200, the failure
+is in the endpoint config — check `asterisk -rvvv` for the SIP
+negotiation trace.

--- a/tenants/migrations/0019_rbac_add_voice_permissions.py
+++ b/tenants/migrations/0019_rbac_add_voice_permissions.py
@@ -1,0 +1,87 @@
+"""B2 (#182): seed voice.* RBAC permission keys for existing tenants.
+
+Adds the voice configuration / call / template / consent / rate-card
+keys to every existing TenantRole's RolePermission table. New tenants
+pick them up automatically via ``seed_default_roles``.
+
+Reverse migration deletes the rows so the down-path is clean.
+"""
+
+from django.db import migrations
+
+# Per role slug → permission key → granted?
+VOICE_PERMISSION_GRANTS: dict[str, dict[str, bool]] = {
+    # Configuration / provider
+    "voice.provider.view": {"owner": True, "admin": True, "manager": True},
+    "voice.provider.create": {"owner": True, "admin": True},
+    "voice.provider.edit": {"owner": True, "admin": True},
+    "voice.provider.delete": {"owner": True, "admin": True},
+    "voice.config.view": {"owner": True, "admin": True, "manager": True},
+    "voice.config.edit": {"owner": True, "admin": True},
+    # Calls
+    "voice.call.view": {
+        "owner": True,
+        "admin": True,
+        "manager": True,
+        "agent": True,
+        "viewer": True,
+    },
+    "voice.call.initiate": {
+        "owner": True,
+        "admin": True,
+        "manager": True,
+        "agent": True,
+    },
+    "voice.call.recording.play": {
+        "owner": True,
+        "admin": True,
+        "manager": True,
+        "agent": True,
+        "viewer": True,
+    },
+    "voice.call.recording.download": {
+        "owner": True,
+        "admin": True,
+        "manager": True,
+    },
+    # Templates (reserved — UI ships later)
+    "voice.template.view": {"owner": True, "admin": True},
+    "voice.template.create": {"owner": True, "admin": True},
+    "voice.template.edit": {"owner": True, "admin": True},
+    "voice.template.delete": {"owner": True, "admin": True},
+    # Recording-consent records
+    "voice.consent.view": {"owner": True, "admin": True},
+    "voice.consent.edit": {"owner": True, "admin": True},
+    # Rate cards
+    "voice.rate_card.view": {"owner": True, "admin": True},
+    "voice.rate_card.edit": {"owner": True, "admin": True},
+}
+
+
+def seed_voice_permissions(apps, schema_editor):
+    TenantRole = apps.get_model("tenants", "TenantRole")
+    RolePermission = apps.get_model("tenants", "RolePermission")
+
+    for role in TenantRole.objects.all().iterator():
+        for perm_key, grants in VOICE_PERMISSION_GRANTS.items():
+            allowed = grants.get(role.slug, False)
+            RolePermission.objects.get_or_create(
+                role=role,
+                permission=perm_key,
+                defaults={"allowed": allowed},
+            )
+
+
+def remove_voice_permissions(apps, schema_editor):
+    RolePermission = apps.get_model("tenants", "RolePermission")
+    RolePermission.objects.filter(permission__in=list(VOICE_PERMISSION_GRANTS)).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tenants", "0018_tenantvoiceapp_recording_requires_consent"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_voice_permissions, remove_voice_permissions),
+    ]

--- a/tenants/permissions.py
+++ b/tenants/permissions.py
@@ -67,6 +67,30 @@ ALL_PERMISSIONS = [
     "product.manage",
     # Analytics
     "analytics.view",
+    # ── Voice (B2 #182) ──────────────────────────────────────────────────
+    # Configuration / provider (admin tier)
+    "voice.provider.view",
+    "voice.provider.create",
+    "voice.provider.edit",
+    "voice.provider.delete",
+    "voice.config.view",
+    "voice.config.edit",
+    # Calls (operator tier)
+    "voice.call.view",
+    "voice.call.initiate",
+    "voice.call.recording.play",
+    "voice.call.recording.download",
+    # Templates (reserved — UI ships later)
+    "voice.template.view",
+    "voice.template.create",
+    "voice.template.edit",
+    "voice.template.delete",
+    # Recording-consent records
+    "voice.consent.view",
+    "voice.consent.edit",
+    # Rate cards (admin tier)
+    "voice.rate_card.view",
+    "voice.rate_card.edit",
 ]
 
 # ---------------------------------------------------------------------------
@@ -118,6 +142,25 @@ PERMISSION_DESCRIPTIONS: dict[str, str] = {
     "product.view": "View product catalog",
     "product.manage": "Manage products and catalog",
     "analytics.view": "View analytics and reports",
+    # Voice (B2 #182)
+    "voice.provider.view": "View voice provider connections",
+    "voice.provider.create": "Add new voice provider connections",
+    "voice.provider.edit": "Edit voice provider connections",
+    "voice.provider.delete": "Remove voice provider connections",
+    "voice.config.view": "View voice channel configuration",
+    "voice.config.edit": "Edit voice channel configuration",
+    "voice.call.view": "View voice call history",
+    "voice.call.initiate": "Place outbound calls and transfer in-progress calls",
+    "voice.call.recording.play": "Stream voice call recordings",
+    "voice.call.recording.download": "Download voice call recordings",
+    "voice.template.view": "View voice templates",
+    "voice.template.create": "Create voice templates",
+    "voice.template.edit": "Edit voice templates",
+    "voice.template.delete": "Delete voice templates",
+    "voice.consent.view": "View recording-consent records",
+    "voice.consent.edit": "Edit recording-consent records",
+    "voice.rate_card.view": "View voice rate cards",
+    "voice.rate_card.edit": "Edit voice rate cards",
 }
 
 # ---------------------------------------------------------------------------
@@ -172,6 +215,13 @@ DEFAULT_ROLE_PERMISSIONS: dict[str, dict[str, bool]] = {
         "product.view": True,
         "product.manage": True,
         "analytics.view": True,
+        # Voice — operate calls, read provider config (B2 #182)
+        "voice.call.view": True,
+        "voice.call.initiate": True,
+        "voice.call.recording.play": True,
+        "voice.call.recording.download": True,
+        "voice.provider.view": True,
+        "voice.config.view": True,
     },
     "agent": {
         "tenant.view": True,
@@ -185,6 +235,10 @@ DEFAULT_ROLE_PERMISSIONS: dict[str, dict[str, bool]] = {
         "chatflow.view": True,
         "product.view": True,
         "analytics.view": True,
+        # Voice — initiate calls, listen to recordings (B2 #182)
+        "voice.call.view": True,
+        "voice.call.initiate": True,
+        "voice.call.recording.play": True,
     },
     # ── VIEWER: read-only ────────────────────────────────────────────────
     "viewer": {
@@ -199,6 +253,9 @@ DEFAULT_ROLE_PERMISSIONS: dict[str, dict[str, bool]] = {
         "chatflow.view": True,
         "product.view": True,
         "analytics.view": True,
+        # Voice — read-only call history + playback (B2 #182)
+        "voice.call.view": True,
+        "voice.call.recording.play": True,
     },
 }
 

--- a/tenants/tests/test_rbac_comprehensive.py
+++ b/tenants/tests/test_rbac_comprehensive.py
@@ -80,8 +80,12 @@ class PermissionRegistryTests(TestCase):
         self.assertEqual(len(ALL_PERMISSIONS), len(set(ALL_PERMISSIONS)))
 
     def test_all_permissions_count(self):
-        """Sanity check that we have the expected number of permission keys."""
-        self.assertEqual(len(ALL_PERMISSIONS), 43)
+        """Sanity check that we have the expected number of permission keys.
+
+        Bumped from 43 → 61 when the voice channel landed its 18 voice.*
+        RBAC keys in #182 (B2).
+        """
+        self.assertEqual(len(ALL_PERMISSIONS), 61)
 
     def test_default_roles_have_entries(self):
         for slug in DefaultRoleSlugs.values:
@@ -107,10 +111,15 @@ class PermissionRegistryTests(TestCase):
 
     def test_viewer_only_has_view_permissions(self):
         viewer_perms = DEFAULT_ROLE_PERMISSIONS["viewer"]
+        # ``voice.call.recording.play`` is read-side (listening to a stored
+        # recording does not mutate state) but doesn't carry the ``.view``
+        # suffix because "play" is the canonical verb for media playback —
+        # see #182 (B2) for the rationale.
+        VIEWER_READ_EXCEPTIONS = {"billing.view", "voice.call.recording.play"}
         for perm, allowed in viewer_perms.items():
             if allowed:
                 self.assertTrue(
-                    perm.endswith(".view") or perm == "billing.view",
+                    perm.endswith(".view") or perm in VIEWER_READ_EXCEPTIONS,
                     f"VIEWER has non-view permission '{perm}' set to True",
                 )
 
@@ -171,8 +180,11 @@ class HasPermissionFunctionTests(TestCase):
             self.assertTrue(has_permission(self.owner_role, perm), f"OWNER should have '{perm}'")
 
     def test_viewer_denied_create_permissions(self):
+        # See note in ``test_viewer_only_has_view_permissions`` — viewer's
+        # read-side permissions are not strictly ``.view``-suffixed.
+        VIEWER_READ_EXCEPTIONS = {"billing.view", "voice.call.recording.play"}
         for perm in ALL_PERMISSIONS:
-            if not perm.endswith(".view") and perm != "billing.view":
+            if not perm.endswith(".view") and perm not in VIEWER_READ_EXCEPTIONS:
                 self.assertFalse(has_permission(self.viewer_role, perm), f"VIEWER should NOT have '{perm}'")
 
     def test_unknown_permission_denied(self):
@@ -3100,8 +3112,13 @@ class PreProductionSweepTests(RBACIntegrationBase):
     # ── 5. Permission Registry Completeness ────────────────────────────
 
     def test_all_permissions_count_is_43(self):
-        """#255: ALL_PERMISSIONS has exactly 43 keys after all RBAC tickets."""
-        self.assertEqual(len(ALL_PERMISSIONS), 43)
+        """#255 sweep: ALL_PERMISSIONS key count.
+
+        Was 43 after the RBAC bring-up tickets; bumped to 61 in #182 (B2)
+        when 18 voice.* keys were added. Method name kept for grep
+        continuity.
+        """
+        self.assertEqual(len(ALL_PERMISSIONS), 61)
 
     def test_every_permission_has_description(self):
         """#255: Every key in ALL_PERMISSIONS has a description."""

--- a/voice/migrations/0005_voiceproviderconfig_default_flag_mutex.py
+++ b/voice/migrations/0005_voiceproviderconfig_default_flag_mutex.py
@@ -1,0 +1,27 @@
+# B3 (#183): enforce mutex on is_default_outbound / is_default_inbound per tenant.
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("voice", "0004_rename_voice_recor_tenant__idx_voice_recor_tenant__a286dc_idx_and_more"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="voiceproviderconfig",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("is_default_outbound", True)),
+                fields=("tenant",),
+                name="voiceconfig_unique_default_outbound_per_tenant",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="voiceproviderconfig",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("is_default_inbound", True)),
+                fields=("tenant",),
+                name="voiceconfig_unique_default_inbound_per_tenant",
+            ),
+        ),
+    ]

--- a/voice/migrations/0005_voiceproviderconfig_default_flag_mutex.py
+++ b/voice/migrations/0005_voiceproviderconfig_default_flag_mutex.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="voiceproviderconfig",
             constraint=models.UniqueConstraint(
-                condition=models.Q(("is_default_outbound", True)),
+                condition=models.Q(is_default_outbound=True),
                 fields=("tenant",),
                 name="voiceconfig_unique_default_outbound_per_tenant",
             ),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="voiceproviderconfig",
             constraint=models.UniqueConstraint(
-                condition=models.Q(("is_default_inbound", True)),
+                condition=models.Q(is_default_inbound=True),
                 fields=("tenant",),
                 name="voiceconfig_unique_default_inbound_per_tenant",
             ),

--- a/voice/migrations/0006_voicecallevent_aggregate_index.py
+++ b/voice/migrations/0006_voicecallevent_aggregate_index.py
@@ -1,0 +1,19 @@
+# B4 (#184/#185 review): composite index supporting probe_config's
+# GROUP BY event_type aggregate over a single provider config's events.
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("voice", "0005_voiceproviderconfig_default_flag_mutex"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="voicecallevent",
+            index=models.Index(
+                fields=["call", "event_type", "-occurred_at"],
+                name="voice_event_call_type_t_idx",
+            ),
+        ),
+    ]

--- a/voice/models.py
+++ b/voice/models.py
@@ -137,6 +137,22 @@ class VoiceProviderConfig(BaseTenantModelForFilterUser):
             models.Index(fields=["tenant", "provider"]),
             models.Index(fields=["tenant", "enabled", "priority"]),
         ]
+        constraints = [
+            # At most one default-outbound config per tenant. Without the
+            # partial unique index two admins racing the "set default"
+            # action could leave the tenant with two defaults — the
+            # outbound resolver would then pick one non-deterministically.
+            models.UniqueConstraint(
+                fields=["tenant"],
+                condition=models.Q(is_default_outbound=True),
+                name="voiceconfig_unique_default_outbound_per_tenant",
+            ),
+            models.UniqueConstraint(
+                fields=["tenant"],
+                condition=models.Q(is_default_inbound=True),
+                name="voiceconfig_unique_default_inbound_per_tenant",
+            ),
+        ]
 
     def __str__(self) -> str:
         label = self.vendor_label or self.get_provider_display()

--- a/voice/models.py
+++ b/voice/models.py
@@ -327,6 +327,16 @@ class VoiceCallEvent(BaseTenantModelForFilterUser):
         verbose_name_plural = "Voice call events"
         indexes = [
             models.Index(fields=["call", "sequence"]),
+            # B4 webhook-reachability aggregate. ``probe_config`` issues
+            # ``GROUP BY event_type`` over the events of one provider
+            # config; the (call, event_type, occurred_at DESC) composite
+            # lets that aggregate stay cheap as event volume grows.
+            # Without it, a per-route MAX(occurred_at) scan dominates on
+            # configs with millions of rows. (#185 review)
+            models.Index(
+                fields=["call", "event_type", "-occurred_at"],
+                name="voice_event_call_type_t_idx",
+            ),
         ]
         ordering = ["call", "sequence"]
 

--- a/voice/permissions.py
+++ b/voice/permissions.py
@@ -44,19 +44,22 @@ def _user_has_voice_perm(user, perm_key: str) -> bool:
     tenant role.
 
     The RBAC layer (``tenants.permissions.has_permission``) operates on
-    a single ``TenantRole`` so this helper iterates the user's
-    memberships and short-circuits on the first allow. Avoids the
-    ``user.tenant`` shortcut used by ``TenantRolePermission`` so it
-    works for users whose tenant is not pinned on the request.
+    a single ``TenantRole`` and ``RolePermission`` is the source of
+    truth — so this resolves to a single ``EXISTS`` round-trip joining
+    the user's active ``TenantUser`` rows to ``RolePermission`` rather
+    than the per-tenant Python loop the first iteration shipped. Avoids
+    the ``user.tenant`` shortcut used by ``TenantRolePermission`` so
+    it works for users whose tenant is not pinned on the request.
+    (#185 review nit)
     """
-    from tenants.models import TenantUser
-    from tenants.permissions import has_permission
+    from tenants.models import RolePermission
 
-    tenant_users = TenantUser.objects.filter(user=user, is_active=True).select_related("role")
-    for tu in tenant_users:
-        if tu.role and has_permission(tu.role, perm_key):
-            return True
-    return False
+    return RolePermission.objects.filter(
+        role__members__user=user,
+        role__members__is_active=True,
+        permission=perm_key,
+        allowed=True,
+    ).exists()
 
 
 class IsVoiceAdmin(BasePermission):

--- a/voice/permissions.py
+++ b/voice/permissions.py
@@ -7,11 +7,8 @@ Two gates layered on top of ``IsAuthenticated``:
     tenant without voice provisioning sees the same 403 a non-member
     would — no info-leak via differential responses.
   * ``IsVoiceAdmin`` — applied to endpoints that touch
-    ``VoiceProviderConfig`` / ``VoiceRateCard``. Falls back to
-    ``is_staff`` since the project's RBAC layer is per-channel and the
-    voice-specific permission strings haven't been wired into the seed
-    role yet — staff users keep working, regular tenant users can't
-    poke at provider credentials.
+    ``VoiceProviderConfig`` / ``VoiceRateCard``. Checks the RBAC
+    permission key ``voice.provider.edit`` (B2 #182). Staff users bypass.
 """
 
 from __future__ import annotations
@@ -42,13 +39,40 @@ class IsVoiceEnabledForTenant(BasePermission):
         ).exists()
 
 
-class IsVoiceAdmin(BasePermission):
-    """Restrict provider-credential / rate-card endpoints to staff.
+def _user_has_voice_perm(user, perm_key: str) -> bool:
+    """True if ``user`` has *perm_key* granted on at least one active
+    tenant role.
 
-    Staff bypass tenants entirely. Non-staff users that are
-    ``TenantUser`` rows with an ``OWNER`` / ``ADMIN`` role on at least
-    one tenant also qualify — keeps regular agents out of credential
-    UIs without coupling the voice app to a specific RBAC seed.
+    The RBAC layer (``tenants.permissions.has_permission``) operates on
+    a single ``TenantRole`` so this helper iterates the user's
+    memberships and short-circuits on the first allow. Avoids the
+    ``user.tenant`` shortcut used by ``TenantRolePermission`` so it
+    works for users whose tenant is not pinned on the request.
+    """
+    from tenants.models import TenantUser
+    from tenants.permissions import has_permission
+
+    tenant_users = TenantUser.objects.filter(user=user, is_active=True).select_related("role")
+    for tu in tenant_users:
+        if tu.role and has_permission(tu.role, perm_key):
+            return True
+    return False
+
+
+class IsVoiceAdmin(BasePermission):
+    """Restrict provider-credential / rate-card endpoints to admins.
+
+    A user passes if either:
+
+      * ``request.user.is_staff`` (superuser bypass), or
+      * any of the user's active tenant roles grants
+        ``voice.provider.edit`` (the canonical voice-admin RBAC key
+        seeded by tenants migration 0019).
+
+    Falling back to staff keeps the gate working when a tenant's role
+    rows haven't been re-seeded — voice.* keys are auto-granted to
+    OWNER/ADMIN on tenant creation via the ``Tenant.post_save`` signal,
+    and the data migration back-fills existing tenants.
     """
 
     message = "Voice provider configuration is admin-only."
@@ -59,14 +83,39 @@ class IsVoiceAdmin(BasePermission):
             return False
         if user.is_staff:
             return True
-        # Best-effort RBAC check — the role names vary across seed
-        # data, but ADMIN / OWNER are the canonical "can manage
-        # config" tiers.
-        try:
-            from tenants.models import TenantUser
-        except ImportError:  # pragma: no cover — defensive
+        return _user_has_voice_perm(user, "voice.provider.edit")
+
+
+class HasVoicePermission(BasePermission):
+    """Generic gate that reads the required key from the viewset.
+
+    The viewset declares a ``voice_required_permission`` attribute (or
+    a per-action dict via ``voice_required_permissions``). The gate
+    resolves the active action, looks up the matching key, and checks
+    it against the user's tenant roles.
+
+    Drop-in replacement for ``IsVoiceAdmin`` when the viewset needs
+    per-action granularity (e.g. recordings: ``play`` vs. ``download``).
+    """
+
+    message = "You do not have the required voice permission for this action."
+
+    def has_permission(self, request, view) -> bool:
+        user = getattr(request, "user", None)
+        if user is None or not user.is_authenticated:
             return False
-        return TenantUser.objects.filter(
-            user=user,
-            role__name__in=("OWNER", "ADMIN", "Owner", "Admin"),
-        ).exists()
+        if user.is_staff:
+            return True
+
+        per_action = getattr(view, "voice_required_permissions", None)
+        if per_action:
+            action = getattr(view, "action", None) or request.method.lower()
+            perm_key = per_action.get(action) or per_action.get("default")
+        else:
+            perm_key = getattr(view, "voice_required_permission", None)
+
+        if not perm_key:
+            # No key declared → fall through to the rest of the
+            # permission stack (deny-only-when-keyed).
+            return True
+        return _user_has_voice_perm(user, perm_key)

--- a/voice/serializers.py
+++ b/voice/serializers.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from rest_framework import serializers
 
 from tenants.models import TenantVoiceApp
@@ -98,17 +98,35 @@ class VoiceProviderConfigSerializer(serializers.ModelSerializer):
                 qs = qs.exclude(pk=exclude_pk)
             qs.update(**{flag: False})
 
+    @staticmethod
+    def _raise_default_race(flag: str) -> None:
+        # Read-committed isolation lets two concurrent transactions
+        # both see "no current default" during their respective
+        # ``_demote_existing_defaults`` and proceed to flip themselves
+        # to True — the partial unique constraint then 500s the second
+        # commit. Translate to a 400 so the caller can retry rather
+        # than seeing an opaque server error. (#185 review)
+        raise serializers.ValidationError({flag: "Another default was promoted concurrently; please retry."})
+
     def create(self, validated_data):
         tenant = validated_data.get("tenant")
-        with transaction.atomic():
-            if tenant is not None:
-                self._demote_existing_defaults(tenant, validated_data)
-            return super().create(validated_data)
+        try:
+            with transaction.atomic():
+                if tenant is not None:
+                    self._demote_existing_defaults(tenant, validated_data)
+                return super().create(validated_data)
+        except IntegrityError:
+            flag = "is_default_outbound" if validated_data.get("is_default_outbound") else "is_default_inbound"
+            self._raise_default_race(flag)
 
     def update(self, instance, validated_data):
-        with transaction.atomic():
-            self._demote_existing_defaults(instance.tenant, validated_data, exclude_pk=instance.pk)
-            return super().update(instance, validated_data)
+        try:
+            with transaction.atomic():
+                self._demote_existing_defaults(instance.tenant, validated_data, exclude_pk=instance.pk)
+                return super().update(instance, validated_data)
+        except IntegrityError:
+            flag = "is_default_outbound" if validated_data.get("is_default_outbound") else "is_default_inbound"
+            self._raise_default_race(flag)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/voice/serializers.py
+++ b/voice/serializers.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 
+from django.db import transaction
 from rest_framework import serializers
 
 from tenants.models import TenantVoiceApp
@@ -77,6 +78,37 @@ class VoiceProviderConfigSerializer(serializers.ModelSerializer):
             except VoiceCredentialError as exc:
                 raise serializers.ValidationError({"credentials": str(exc)}) from exc
         return super().validate(attrs)
+
+    # ── B3 (#183): transactional default-flag mutex ───────────────────────
+    # The model has partial unique constraints on (tenant) conditioned on
+    # is_default_outbound=True / is_default_inbound=True. Naive save() on
+    # a row that flips a flag to True while another row in the same tenant
+    # already holds it would raise IntegrityError. We flip the existing
+    # holder off in the same transaction so the API does the safe thing
+    # by default — the alternative (two PATCHes from the frontend) has a
+    # race window between the demote and the promote.
+    _DEFAULT_FLAGS = ("is_default_outbound", "is_default_inbound")
+
+    def _demote_existing_defaults(self, tenant, validated_data, *, exclude_pk=None) -> None:
+        for flag in self._DEFAULT_FLAGS:
+            if not validated_data.get(flag):
+                continue
+            qs = VoiceProviderConfig.objects.filter(tenant=tenant, **{flag: True})
+            if exclude_pk is not None:
+                qs = qs.exclude(pk=exclude_pk)
+            qs.update(**{flag: False})
+
+    def create(self, validated_data):
+        tenant = validated_data.get("tenant")
+        with transaction.atomic():
+            if tenant is not None:
+                self._demote_existing_defaults(tenant, validated_data)
+            return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        with transaction.atomic():
+            self._demote_existing_defaults(instance.tenant, validated_data, exclude_pk=instance.pk)
+            return super().update(instance, validated_data)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/voice/sip_config/ari_client.py
+++ b/voice/sip_config/ari_client.py
@@ -173,3 +173,17 @@ class AriClient:
         # when supported; fallback callers can read from disk.
         resp = self._request("GET", f"ari/recordings/stored/{recording_name}/file")
         return resp.content
+
+    # ── Health / discovery (B1 #181) ────────────────────────────────────
+
+    def asterisk_info(self) -> dict:
+        """Return Asterisk system info via ``GET /ari/asterisk/info``.
+
+        Used by the health endpoint to confirm ARI reachability and
+        report the running Asterisk version back to the frontend.
+        """
+        return self._request("GET", "ari/asterisk/info").json()
+
+    def list_endpoints(self) -> list[dict]:
+        """Return registered PJSIP endpoints via ``GET /ari/endpoints``."""
+        return self._request("GET", "ari/endpoints").json()

--- a/voice/tests/test_ari_health.py
+++ b/voice/tests/test_ari_health.py
@@ -1,0 +1,133 @@
+"""B1 (#181): Asterisk ARI health endpoint.
+
+Covers the four states the frontend SIP wizard cares about:
+
+  * ARI URL not configured → 503 with a clear reason.
+  * ARI configured but unreachable (connection refused, etc.) → 503.
+  * ARI configured but returns an error (auth fail, 500) → 503.
+  * Happy path → 200 with ``asterisk_version`` + ``endpoints_registered``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import requests
+from rest_framework.test import APIClient
+
+from tenants.models import Tenant, TenantRole, TenantUser, TenantVoiceApp
+
+
+@pytest.fixture()
+def tenant(db):
+    return Tenant.objects.create(name="AriHealthTenant")
+
+
+@pytest.fixture()
+def voice_app(tenant):
+    return TenantVoiceApp.objects.create(tenant=tenant, is_enabled=True)
+
+
+@pytest.fixture()
+def user_client(db, tenant, voice_app):
+    from django.contrib.auth import get_user_model
+
+    role = TenantRole.objects.get(tenant=tenant, slug="agent")
+    user = get_user_model().objects.create_user(
+        username="ari_health_user",
+        email="arih@t.io",
+        mobile="+919600007001",
+        password="x",
+    )
+    TenantUser.objects.create(tenant=tenant, user=user, role=role, is_active=True)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+URL = "/voice/v1/api/ari-health/"
+
+
+class TestAriHealth:
+    def test_unauthenticated_blocked(self, db, voice_app):
+        resp = APIClient().get(URL)
+        assert resp.status_code in (401, 403)
+
+    def test_tenant_without_voice_forbidden(self, db, tenant):
+        # No TenantVoiceApp at all on this tenant.
+        from django.contrib.auth import get_user_model
+
+        role = TenantRole.objects.get(tenant=tenant, slug="agent")
+        user = get_user_model().objects.create_user(
+            username="no_voice_user",
+            email="nv@t.io",
+            mobile="+919600007002",
+            password="x",
+        )
+        TenantUser.objects.create(tenant=tenant, user=user, role=role, is_active=True)
+        c = APIClient()
+        c.force_authenticate(user=user)
+        resp = c.get(URL)
+        assert resp.status_code == 403
+
+    def test_returns_503_when_ari_url_unset(self, user_client, settings):
+        settings.ASTERISK_ARI_URL = ""
+        resp = user_client.get(URL)
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["ok"] is False
+        assert "ASTERISK_ARI_URL" in body["reason"]
+
+    def test_returns_503_on_connection_error(self, user_client, settings):
+        settings.ASTERISK_ARI_URL = "http://127.0.0.1:18088"
+        with patch(
+            "voice.sip_config.ari_client.AriClient.asterisk_info",
+            side_effect=requests.ConnectionError("connection refused"),
+        ):
+            resp = user_client.get(URL)
+        assert resp.status_code == 503
+        assert resp.json()["ok"] is False
+
+    def test_returns_503_on_ari_error(self, user_client, settings):
+        from voice.sip_config.ari_client import AriError
+
+        settings.ASTERISK_ARI_URL = "http://127.0.0.1:18088"
+        with patch(
+            "voice.sip_config.ari_client.AriClient.asterisk_info",
+            side_effect=AriError(401, "unauthorized"),
+        ):
+            resp = user_client.get(URL)
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["ok"] is False
+        assert "401" in body["reason"]
+
+    def test_happy_path(self, user_client, settings):
+        settings.ASTERISK_ARI_URL = "http://127.0.0.1:8088"
+        info = {"system": {"version": "20.6.0"}}
+        endpoints = [{"technology": "PJSIP", "resource": "ep-a"}, {"technology": "PJSIP", "resource": "ep-b"}]
+        with (
+            patch("voice.sip_config.ari_client.AriClient.asterisk_info", return_value=info),
+            patch("voice.sip_config.ari_client.AriClient.list_endpoints", return_value=endpoints),
+        ):
+            resp = user_client.get(URL)
+        assert resp.status_code == 200, resp.content
+        body = resp.json()
+        assert body == {"ok": True, "asterisk_version": "20.6.0", "endpoints_registered": 2}
+
+    def test_happy_path_version_fallback(self, user_client, settings):
+        # Some Asterisk builds expose ``version`` at the top level rather
+        # than under ``system`` — the view should fall back gracefully.
+        settings.ASTERISK_ARI_URL = "http://127.0.0.1:8088"
+        with (
+            patch(
+                "voice.sip_config.ari_client.AriClient.asterisk_info",
+                return_value={"version": "18.20.0"},
+            ),
+            patch("voice.sip_config.ari_client.AriClient.list_endpoints", return_value=[]),
+        ):
+            resp = user_client.get(URL)
+        assert resp.status_code == 200
+        assert resp.json()["asterisk_version"] == "18.20.0"
+        assert resp.json()["endpoints_registered"] == 0

--- a/voice/tests/test_ari_health.py
+++ b/voice/tests/test_ari_health.py
@@ -103,7 +103,10 @@ class TestAriHealth:
         assert body["ok"] is False
         assert "401" in body["reason"]
 
-    def test_happy_path(self, user_client, settings):
+    def test_happy_path_hides_endpoint_count_for_non_staff(self, user_client, settings):
+        # Non-staff users get the boolean + version only; the box-wide
+        # endpoints_registered count is staff-gated to prevent
+        # cross-tenant inference. (#185 review)
         settings.ASTERISK_ARI_URL = "http://127.0.0.1:8088"
         info = {"system": {"version": "20.6.0"}}
         endpoints = [{"technology": "PJSIP", "resource": "ep-a"}, {"technology": "PJSIP", "resource": "ep-b"}]
@@ -114,7 +117,39 @@ class TestAriHealth:
             resp = user_client.get(URL)
         assert resp.status_code == 200, resp.content
         body = resp.json()
-        assert body == {"ok": True, "asterisk_version": "20.6.0", "endpoints_registered": 2}
+        assert body == {"ok": True, "asterisk_version": "20.6.0"}
+        assert "endpoints_registered" not in body
+
+    def test_happy_path_exposes_endpoint_count_for_staff(self, db, tenant, voice_app, settings):
+        from django.contrib.auth import get_user_model
+        from rest_framework.test import APIClient as _APIClient
+
+        role = TenantRole.objects.get(tenant=tenant, slug="agent")
+        user = get_user_model().objects.create_user(
+            username="ari_staff",
+            email="aris@t.io",
+            mobile="+919600007003",
+            password="x",
+            is_staff=True,
+        )
+        TenantUser.objects.create(tenant=tenant, user=user, role=role, is_active=True)
+        c = _APIClient()
+        c.force_authenticate(user=user)
+        settings.ASTERISK_ARI_URL = "http://127.0.0.1:8088"
+        with (
+            patch(
+                "voice.sip_config.ari_client.AriClient.asterisk_info",
+                return_value={"system": {"version": "20.6.0"}},
+            ),
+            patch(
+                "voice.sip_config.ari_client.AriClient.list_endpoints",
+                return_value=[{"resource": "a"}, {"resource": "b"}],
+            ),
+        ):
+            resp = c.get(URL)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["endpoints_registered"] == 2
 
     def test_happy_path_version_fallback(self, user_client, settings):
         # Some Asterisk builds expose ``version`` at the top level rather
@@ -130,4 +165,4 @@ class TestAriHealth:
             resp = user_client.get(URL)
         assert resp.status_code == 200
         assert resp.json()["asterisk_version"] == "18.20.0"
-        assert resp.json()["endpoints_registered"] == 0
+        assert "endpoints_registered" not in resp.json()

--- a/voice/tests/test_default_flag_mutex.py
+++ b/voice/tests/test_default_flag_mutex.py
@@ -1,0 +1,173 @@
+"""B3 (#183): default-flag mutex on VoiceProviderConfig.
+
+Covers the partial unique constraints at the DB layer and the
+serializer-level transactional demotion that the REST API performs so
+callers don't have to do the demote-then-promote dance themselves.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.db import IntegrityError, transaction
+from rest_framework.test import APIClient
+
+from tenants.models import Tenant, TenantRole, TenantUser, TenantVoiceApp
+from voice.constants import VoiceProvider
+from voice.models import VoiceProviderConfig
+
+
+def _make_cfg(tenant, **extra):
+    return VoiceProviderConfig.objects.create(
+        tenant=tenant,
+        name=extra.pop("name", "cfg"),
+        provider=extra.pop("provider", VoiceProvider.TWILIO),
+        credentials=json.dumps({"account_sid": "AC1", "auth_token": "t"}),
+        from_numbers=["+14155550100"],
+        **extra,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DB-level: partial unique constraints
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestDefaultFlagDatabaseConstraints:
+    def test_two_default_outbound_in_same_tenant_rejected(self):
+        tenant = Tenant.objects.create(name="MutexTenant")
+        _make_cfg(tenant, name="a", is_default_outbound=True)
+        with transaction.atomic(), pytest.raises(IntegrityError):
+            _make_cfg(tenant, name="b", is_default_outbound=True)
+
+    def test_two_default_inbound_in_same_tenant_rejected(self):
+        tenant = Tenant.objects.create(name="MutexTenant2")
+        _make_cfg(tenant, name="a", is_default_inbound=True)
+        with transaction.atomic(), pytest.raises(IntegrityError):
+            _make_cfg(tenant, name="b", is_default_inbound=True)
+
+    def test_default_outbound_and_inbound_can_coexist_on_one_config(self):
+        # The two constraints are independent — a single config holding
+        # both flags is the common single-provider tenant case.
+        tenant = Tenant.objects.create(name="MutexTenant3")
+        cfg = _make_cfg(tenant, name="solo", is_default_outbound=True, is_default_inbound=True)
+        assert cfg.is_default_outbound and cfg.is_default_inbound
+
+    def test_defaults_isolated_per_tenant(self):
+        t1 = Tenant.objects.create(name="T1")
+        t2 = Tenant.objects.create(name="T2")
+        _make_cfg(t1, name="t1-default", is_default_outbound=True)
+        # Same flag in a different tenant must be allowed.
+        _make_cfg(t2, name="t2-default", is_default_outbound=True)
+
+    def test_non_default_rows_unrestricted(self):
+        tenant = Tenant.objects.create(name="MutexTenant4")
+        _make_cfg(tenant, name="a", is_default_outbound=False)
+        _make_cfg(tenant, name="b", is_default_outbound=False)
+        _make_cfg(tenant, name="c", is_default_outbound=False)
+        # No raise.
+        assert VoiceProviderConfig.objects.filter(tenant=tenant).count() == 3
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Serializer-level: transactional demotion via REST
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def tenant(db):
+    return Tenant.objects.create(name="MutexAPITenant")
+
+
+@pytest.fixture()
+def admin_user(db, tenant):
+    from django.contrib.auth import get_user_model
+
+    role, _ = TenantRole.objects.get_or_create(tenant=tenant, slug="owner", defaults={"name": "Owner", "priority": 100})
+    user = get_user_model().objects.create_user(
+        username="mutex_admin",
+        email="ma@test.com",
+        mobile="+919600009000",
+        password="x",
+    )
+    TenantUser.objects.create(tenant=tenant, user=user, role=role, is_active=True)
+    return user
+
+
+@pytest.fixture()
+def voice_app(tenant):
+    return TenantVoiceApp.objects.create(tenant=tenant, is_enabled=True)
+
+
+@pytest.fixture()
+def api(admin_user):
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+class TestDefaultFlagSerializerMutex:
+    def test_create_new_default_demotes_existing(self, api, tenant, voice_app):
+        existing = _make_cfg(tenant, name="existing", is_default_outbound=True)
+        resp = api.post(
+            "/voice/v1/api/provider-configs/",
+            data={
+                "name": "challenger",
+                "provider": VoiceProvider.TWILIO,
+                "credentials": {"account_sid": "AC2", "auth_token": "t2"},
+                "from_numbers": ["+14155550101"],
+                "is_default_outbound": True,
+            },
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+        existing.refresh_from_db()
+        assert existing.is_default_outbound is False
+        # New row is now the sole default-outbound.
+        defaults = VoiceProviderConfig.objects.filter(tenant=tenant, is_default_outbound=True)
+        assert defaults.count() == 1
+        assert defaults.first().name == "challenger"
+
+    def test_patch_to_default_demotes_existing(self, api, tenant, voice_app):
+        existing = _make_cfg(tenant, name="old-default", is_default_inbound=True)
+        challenger = _make_cfg(tenant, name="challenger", is_default_inbound=False)
+        resp = api.patch(
+            f"/voice/v1/api/provider-configs/{challenger.id}/",
+            data={"is_default_inbound": True},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        existing.refresh_from_db()
+        challenger.refresh_from_db()
+        assert existing.is_default_inbound is False
+        assert challenger.is_default_inbound is True
+
+    def test_non_default_create_does_not_disturb_existing(self, api, tenant, voice_app):
+        existing = _make_cfg(tenant, name="existing", is_default_outbound=True)
+        resp = api.post(
+            "/voice/v1/api/provider-configs/",
+            data={
+                "name": "innocuous",
+                "provider": VoiceProvider.TWILIO,
+                "credentials": {"account_sid": "AC2", "auth_token": "t2"},
+                "from_numbers": ["+14155550102"],
+                "is_default_outbound": False,
+            },
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+        existing.refresh_from_db()
+        assert existing.is_default_outbound is True
+
+    def test_patch_self_to_default_when_already_default_is_noop(self, api, tenant, voice_app):
+        cfg = _make_cfg(tenant, name="self", is_default_outbound=True)
+        resp = api.patch(
+            f"/voice/v1/api/provider-configs/{cfg.id}/",
+            data={"is_default_outbound": True},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        cfg.refresh_from_db()
+        assert cfg.is_default_outbound is True

--- a/voice/tests/test_default_flag_mutex.py
+++ b/voice/tests/test_default_flag_mutex.py
@@ -208,4 +208,7 @@ class TestDefaultFlagSerializerMutex:
         assert resp.status_code == 400, resp.content
         body = resp.json()
         assert "is_default_outbound" in body
-        assert "concurrently" in body["is_default_outbound"][0].lower()
+        # DRF may serialise the field value as a bare string or a
+        # one-element list depending on how ValidationError was raised;
+        # both forms are valid. Coerce to string before substring check.
+        assert "concurrently" in str(body["is_default_outbound"]).lower()

--- a/voice/tests/test_default_flag_mutex.py
+++ b/voice/tests/test_default_flag_mutex.py
@@ -171,3 +171,41 @@ class TestDefaultFlagSerializerMutex:
         assert resp.status_code == 200, resp.content
         cfg.refresh_from_db()
         assert cfg.is_default_outbound is True
+
+    def test_integrityerror_race_returns_400_not_500(self, api, tenant, voice_app, monkeypatch):
+        """B3 race: two concurrent transactions both pass the demote
+        check (each sees no committed default after the other's
+        uncommitted demote), the partial unique index then rejects the
+        second commit. The serializer must translate the
+        ``IntegrityError`` into a 400 ``ValidationError`` so the
+        frontend can show a retry message instead of an opaque 500.
+
+        We simulate the race by short-circuiting the demote step (no-op)
+        so the second create races straight at the constraint, the same
+        way two parallel transactions would after both pass demote.
+        """
+        # Pre-existing default-outbound row that *won't* be demoted.
+        _make_cfg(tenant, name="incumbent", is_default_outbound=True)
+
+        from voice.serializers import VoiceProviderConfigSerializer
+
+        monkeypatch.setattr(
+            VoiceProviderConfigSerializer,
+            "_demote_existing_defaults",
+            lambda *a, **kw: None,
+        )
+        resp = api.post(
+            "/voice/v1/api/provider-configs/",
+            data={
+                "name": "challenger",
+                "provider": VoiceProvider.TWILIO,
+                "credentials": {"account_sid": "AC2", "auth_token": "t2"},
+                "from_numbers": ["+14155550144"],
+                "is_default_outbound": True,
+            },
+            format="json",
+        )
+        assert resp.status_code == 400, resp.content
+        body = resp.json()
+        assert "is_default_outbound" in body
+        assert "concurrently" in body["is_default_outbound"][0].lower()

--- a/voice/tests/test_rbac_voice_keys.py
+++ b/voice/tests/test_rbac_voice_keys.py
@@ -1,0 +1,184 @@
+"""B2 (#182): voice.* RBAC permission keys + role mappings.
+
+Confirms:
+
+  * Every expected ``voice.*`` key is in ``ALL_PERMISSIONS``.
+  * After ``seed_default_roles``, the per-role grant matches the
+    ticket's role matrix exactly.
+  * ``IsVoiceAdmin`` checks ``voice.provider.edit`` instead of the
+    legacy role-name list — i.e. an OWNER passes, an AGENT does not,
+    and a staff user passes regardless.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tenants.models import RolePermission, Tenant, TenantRole, TenantUser
+from tenants.permissions import (
+    ALL_PERMISSIONS,
+    DEFAULT_ROLE_PERMISSIONS,
+    PERMISSION_DESCRIPTIONS,
+    seed_default_roles,
+)
+
+VOICE_KEYS = [k for k in ALL_PERMISSIONS if k.startswith("voice.")]
+
+
+class TestVoicePermissionRegistry:
+    def test_all_expected_voice_keys_registered(self):
+        expected = {
+            "voice.provider.view",
+            "voice.provider.create",
+            "voice.provider.edit",
+            "voice.provider.delete",
+            "voice.config.view",
+            "voice.config.edit",
+            "voice.call.view",
+            "voice.call.initiate",
+            "voice.call.recording.play",
+            "voice.call.recording.download",
+            "voice.template.view",
+            "voice.template.create",
+            "voice.template.edit",
+            "voice.template.delete",
+            "voice.consent.view",
+            "voice.consent.edit",
+            "voice.rate_card.view",
+            "voice.rate_card.edit",
+        }
+        assert set(VOICE_KEYS) == expected
+
+    def test_every_voice_key_has_description(self):
+        for k in VOICE_KEYS:
+            assert k in PERMISSION_DESCRIPTIONS, f"missing description for {k}"
+            assert PERMISSION_DESCRIPTIONS[k]
+
+
+class TestDefaultRoleGrants:
+    """The grant matrix from B2."""
+
+    def test_owner_and_admin_get_all_voice_keys(self):
+        owner = DEFAULT_ROLE_PERMISSIONS["owner"]
+        admin = DEFAULT_ROLE_PERMISSIONS["admin"]
+        for k in VOICE_KEYS:
+            assert owner.get(k) is True, k
+            assert admin.get(k) is True, k
+
+    def test_manager_grants(self):
+        manager = DEFAULT_ROLE_PERMISSIONS["manager"]
+        granted = {k for k in VOICE_KEYS if manager.get(k)}
+        assert granted == {
+            "voice.call.view",
+            "voice.call.initiate",
+            "voice.call.recording.play",
+            "voice.call.recording.download",
+            "voice.provider.view",
+            "voice.config.view",
+        }
+
+    def test_agent_grants(self):
+        agent = DEFAULT_ROLE_PERMISSIONS["agent"]
+        granted = {k for k in VOICE_KEYS if agent.get(k)}
+        assert granted == {
+            "voice.call.view",
+            "voice.call.initiate",
+            "voice.call.recording.play",
+        }
+
+    def test_viewer_grants(self):
+        viewer = DEFAULT_ROLE_PERMISSIONS["viewer"]
+        granted = {k for k in VOICE_KEYS if viewer.get(k)}
+        assert granted == {
+            "voice.call.view",
+            "voice.call.recording.play",
+        }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DB-level: seed_default_roles + migration round-trip
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestSeededRolePermissions:
+    def test_seed_creates_voice_role_permissions(self):
+        tenant = Tenant.objects.create(name="VoiceRBAC")
+        # Signal-driven seeding fires on Tenant.post_save; call again
+        # to confirm idempotency and exercise the function directly.
+        seed_default_roles(tenant)
+
+        owner = TenantRole.objects.get(tenant=tenant, slug="owner")
+        agent = TenantRole.objects.get(tenant=tenant, slug="agent")
+
+        owner_keys = {
+            rp.permission
+            for rp in RolePermission.objects.filter(role=owner, allowed=True, permission__startswith="voice.")
+        }
+        assert set(VOICE_KEYS).issubset(owner_keys)
+
+        agent_keys = {
+            rp.permission
+            for rp in RolePermission.objects.filter(role=agent, allowed=True, permission__startswith="voice.")
+        }
+        assert agent_keys == {
+            "voice.call.view",
+            "voice.call.initiate",
+            "voice.call.recording.play",
+        }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Voice gate: IsVoiceAdmin via RBAC
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def tenant(db):
+    return Tenant.objects.create(name="VoiceAdminRBACTenant")
+
+
+def _user_with_role(tenant, slug, *, username, mobile):
+    from django.contrib.auth import get_user_model
+
+    role = TenantRole.objects.get(tenant=tenant, slug=slug)
+    user = get_user_model().objects.create_user(
+        username=username, email=f"{username}@t.io", mobile=mobile, password="x"
+    )
+    TenantUser.objects.create(tenant=tenant, user=user, role=role, is_active=True)
+    return user
+
+
+class TestIsVoiceAdminRBAC:
+    def test_owner_passes(self, tenant):
+        from rest_framework.test import APIRequestFactory
+
+        from voice.permissions import IsVoiceAdmin
+
+        user = _user_with_role(tenant, "owner", username="owner1", mobile="+919600002001")
+        req = APIRequestFactory().get("/voice/v1/api/provider-configs/")
+        req.user = user
+        assert IsVoiceAdmin().has_permission(req, view=None) is True
+
+    def test_agent_blocked(self, tenant):
+        from rest_framework.test import APIRequestFactory
+
+        from voice.permissions import IsVoiceAdmin
+
+        user = _user_with_role(tenant, "agent", username="agent1", mobile="+919600002002")
+        req = APIRequestFactory().get("/voice/v1/api/provider-configs/")
+        req.user = user
+        assert IsVoiceAdmin().has_permission(req, view=None) is False
+
+    def test_staff_bypass(self, tenant):
+        from django.contrib.auth import get_user_model
+        from rest_framework.test import APIRequestFactory
+
+        from voice.permissions import IsVoiceAdmin
+
+        user = get_user_model().objects.create_user(
+            username="staff", email="s@t.io", mobile="+919600002003", password="x", is_staff=True
+        )
+        req = APIRequestFactory().get("/voice/v1/api/provider-configs/")
+        req.user = user
+        assert IsVoiceAdmin().has_permission(req, view=None) is True

--- a/voice/tests/test_webhook_reachability.py
+++ b/voice/tests/test_webhook_reachability.py
@@ -1,0 +1,225 @@
+"""B4 (#184): webhook reachability probe.
+
+Covers:
+
+  * Per-provider URL discovery — Twilio surfaces 4 webhooks, Plivo 3,
+    Vonage 2, Telnyx 1, Exotel 2, SIP 0.
+  * Passive freshness classification — recent / stale / never.
+  * The ``test-webhooks`` action gates on ``IsVoiceAdmin`` like the rest
+    of provider-config actions.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from tenants.models import Tenant, TenantRole, TenantUser, TenantVoiceApp
+from voice.constants import CallDirection, CallEventType, CallStatus, VoiceProvider
+from voice.models import VoiceCall, VoiceCallEvent, VoiceProviderConfig
+
+
+def _make_cfg(tenant, provider, **extra):
+    creds = {
+        VoiceProvider.TWILIO: {"account_sid": "AC1", "auth_token": "t"},
+        VoiceProvider.PLIVO: {"auth_id": "MA1", "auth_token": "t"},
+        VoiceProvider.VONAGE: {
+            "api_key": "k",
+            "api_secret": "s",
+            "application_id": "00000000-0000-0000-0000-000000000001",
+            "private_key_pem": "p",
+        },
+        VoiceProvider.TELNYX: {"api_key": "tx", "connection_id": "c"},
+        VoiceProvider.EXOTEL: {"sid": "s", "api_key": "k", "api_token": "t"},
+        VoiceProvider.SIP: {
+            "sip_username": "u",
+            "sip_password": "p",
+            "sip_realm": "sip.example.com",
+            "sip_proxy": "sip.example.com",
+        },
+    }[provider]
+    return VoiceProviderConfig.objects.create(
+        tenant=tenant,
+        name=extra.pop("name", f"{provider}-cfg"),
+        provider=provider,
+        credentials=json.dumps(creds),
+        from_numbers=["+14155550100"],
+        **extra,
+    )
+
+
+def _make_event(call, event_type, occurred_at):
+    seq = VoiceCallEvent.objects.filter(call=call).count() + 1
+    return VoiceCallEvent.objects.create(
+        call=call,
+        event_type=event_type,
+        occurred_at=occurred_at,
+        sequence=seq,
+        payload={},
+    )
+
+
+def _make_call(tenant, config):
+    return VoiceCall.objects.create(
+        tenant=tenant,
+        name="rc-call",
+        provider_config=config,
+        provider_call_id="CA_reach",
+        direction=CallDirection.OUTBOUND,
+        from_number="+14155550100",
+        to_number="+14155550199",
+        status=CallStatus.COMPLETED,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pure function: probe_config
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestProbeConfig:
+    def test_twilio_returns_four_routes(self):
+        tenant = Tenant.objects.create(name="ReachTwilio")
+        cfg = _make_cfg(tenant, VoiceProvider.TWILIO)
+        from voice.webhooks.reachability import probe_config
+
+        result = probe_config(cfg)
+        assert result["provider"] == VoiceProvider.TWILIO
+        assert result["probe_type"] == "passive"
+        labels = {r["label"] for r in result["results"]}
+        assert labels == {"call-status", "answer", "gather", "recording-status"}
+
+    def test_telnyx_returns_single_event_route(self):
+        tenant = Tenant.objects.create(name="ReachTelnyx")
+        cfg = _make_cfg(tenant, VoiceProvider.TELNYX)
+        from voice.webhooks.reachability import probe_config
+
+        labels = {r["label"] for r in probe_config(cfg)["results"]}
+        assert labels == {"event"}
+
+    def test_sip_returns_empty_results(self):
+        tenant = Tenant.objects.create(name="ReachSIP")
+        cfg = _make_cfg(tenant, VoiceProvider.SIP)
+        from voice.webhooks.reachability import probe_config
+
+        # SIP has no HTTP webhooks — events arrive via the ARI consumer.
+        assert probe_config(cfg)["results"] == []
+
+    def test_never_status_when_no_events(self):
+        tenant = Tenant.objects.create(name="ReachNoEvent")
+        cfg = _make_cfg(tenant, VoiceProvider.TWILIO)
+        from voice.webhooks.reachability import probe_config
+
+        for row in probe_config(cfg)["results"]:
+            assert row["status"] == "passive_never"
+            assert row["last_received_at"] is None
+            assert row["sample_call_id"] is None
+
+    def test_recent_status_classifies_correctly(self):
+        tenant = Tenant.objects.create(name="ReachRecent")
+        cfg = _make_cfg(tenant, VoiceProvider.TWILIO)
+        call = _make_call(tenant, cfg)
+        _make_event(call, CallEventType.COMPLETED, timezone.now() - timedelta(minutes=2))
+        from voice.webhooks.reachability import probe_config
+
+        result = probe_config(cfg)
+        row = next(r for r in result["results"] if r["label"] == "call-status")
+        assert row["status"] == "passive_recent"
+        assert row["last_received_at"] is not None
+        assert row["sample_call_id"] == str(call.id)
+
+    def test_stale_status_when_event_old(self):
+        tenant = Tenant.objects.create(name="ReachStale")
+        cfg = _make_cfg(tenant, VoiceProvider.TWILIO)
+        call = _make_call(tenant, cfg)
+        _make_event(call, CallEventType.COMPLETED, timezone.now() - timedelta(days=2))
+        from voice.webhooks.reachability import probe_config
+
+        row = next(r for r in probe_config(cfg)["results"] if r["label"] == "call-status")
+        assert row["status"] == "passive_stale"
+
+    def test_label_filters_route_specific(self):
+        # A recording event should mark the recording-status route as
+        # recent but the gather route as never (no DTMF/SPEECH event).
+        tenant = Tenant.objects.create(name="ReachLabel")
+        cfg = _make_cfg(tenant, VoiceProvider.TWILIO)
+        call = _make_call(tenant, cfg)
+        _make_event(call, CallEventType.RECORDING_COMPLETED, timezone.now())
+        from voice.webhooks.reachability import probe_config
+
+        rows = {r["label"]: r for r in probe_config(cfg)["results"]}
+        assert rows["recording-status"]["status"] == "passive_recent"
+        assert rows["gather"]["status"] == "passive_never"
+        # call-status accepts any event so it's also recent.
+        assert rows["call-status"]["status"] == "passive_recent"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoint: POST /provider-configs/{id}/test-webhooks/
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def tenant(db):
+    return Tenant.objects.create(name="ReachAPITenant")
+
+
+@pytest.fixture()
+def voice_app(tenant):
+    return TenantVoiceApp.objects.create(tenant=tenant, is_enabled=True)
+
+
+@pytest.fixture()
+def admin_client(db, tenant, voice_app):
+    from django.contrib.auth import get_user_model
+
+    role = TenantRole.objects.get(tenant=tenant, slug="owner")
+    user = get_user_model().objects.create_user(
+        username="reach_admin", email="ra@t.io", mobile="+919600008001", password="x"
+    )
+    TenantUser.objects.create(tenant=tenant, user=user, role=role, is_active=True)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture()
+def agent_client(db, tenant, voice_app):
+    from django.contrib.auth import get_user_model
+
+    role = TenantRole.objects.get(tenant=tenant, slug="agent")
+    user = get_user_model().objects.create_user(
+        username="reach_agent", email="ra2@t.io", mobile="+919600008002", password="x"
+    )
+    TenantUser.objects.create(tenant=tenant, user=user, role=role, is_active=True)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+class TestTestWebhooksAction:
+    def test_admin_can_probe(self, admin_client, tenant, voice_app):
+        cfg = _make_cfg(tenant, VoiceProvider.TWILIO)
+        resp = admin_client.post(f"/voice/v1/api/provider-configs/{cfg.id}/test-webhooks/")
+        assert resp.status_code == 200, resp.content
+        body = resp.json()
+        assert body["config_id"] == str(cfg.id)
+        assert body["provider"] == VoiceProvider.TWILIO
+        assert body["probe_type"] == "passive"
+        assert len(body["results"]) == 4
+
+    def test_agent_blocked(self, agent_client, tenant, voice_app):
+        cfg = _make_cfg(tenant, VoiceProvider.TWILIO)
+        resp = agent_client.post(f"/voice/v1/api/provider-configs/{cfg.id}/test-webhooks/")
+        assert resp.status_code == 403
+
+    def test_other_tenant_returns_404(self, admin_client, tenant, voice_app):
+        other = Tenant.objects.create(name="OtherReachTenant")
+        cfg = _make_cfg(other, VoiceProvider.TWILIO)
+        resp = admin_client.post(f"/voice/v1/api/provider-configs/{cfg.id}/test-webhooks/")
+        assert resp.status_code == 404

--- a/voice/tests/test_webhook_reachability.py
+++ b/voice/tests/test_webhook_reachability.py
@@ -171,12 +171,14 @@ class TestProbeConfig:
         assert rows["gather"]["inferred_from"] == "event_type"
         assert rows["recording-status"]["inferred_from"] == "event_type"
 
-    def test_aggregate_query_count_is_bounded(self, django_assert_num_queries):
+    def test_aggregate_query_count_is_bounded(self, django_assert_max_num_queries):
         # B4 review feedback: probe_config used to issue N+1 queries
         # (one per route). The aggregate version should land a small,
         # constant number regardless of how many routes the provider
         # has. Twilio has 4 routes; we cap at a generous bound that
-        # still catches the regression if the loop comes back.
+        # still catches the regression if the loop comes back, without
+        # being brittle to small implementation tweaks (max_num_queries
+        # is an upper bound, not equality).
         tenant = Tenant.objects.create(name="ReachQueryCount")
         cfg = _make_cfg(tenant, VoiceProvider.TWILIO)
         call = _make_call(tenant, cfg)
@@ -189,10 +191,7 @@ class TestProbeConfig:
             _make_event(call, et, timezone.now())
         from voice.webhooks.reachability import probe_config
 
-        # 1 aggregate + 1 sample for any-event routes + up to 3 per
-        # filtered route that has a hit. Be generous; the goal is
-        # "constant, not N+1 per route count".
-        with django_assert_num_queries(10):
+        with django_assert_max_num_queries(10):
             probe_config(cfg)
 
 

--- a/voice/tests/test_webhook_reachability.py
+++ b/voice/tests/test_webhook_reachability.py
@@ -158,6 +158,43 @@ class TestProbeConfig:
         # call-status accepts any event so it's also recent.
         assert rows["call-status"]["status"] == "passive_recent"
 
+    def test_inferred_from_flag(self):
+        # call-status / event / status routes are "any event" -> inferred_from=any_event.
+        # answer / gather / recording-status routes are filtered by event type.
+        tenant = Tenant.objects.create(name="ReachInferred")
+        cfg = _make_cfg(tenant, VoiceProvider.TWILIO)
+        from voice.webhooks.reachability import probe_config
+
+        rows = {r["label"]: r for r in probe_config(cfg)["results"]}
+        assert rows["call-status"]["inferred_from"] == "any_event"
+        assert rows["answer"]["inferred_from"] == "event_type"
+        assert rows["gather"]["inferred_from"] == "event_type"
+        assert rows["recording-status"]["inferred_from"] == "event_type"
+
+    def test_aggregate_query_count_is_bounded(self, django_assert_num_queries):
+        # B4 review feedback: probe_config used to issue N+1 queries
+        # (one per route). The aggregate version should land a small,
+        # constant number regardless of how many routes the provider
+        # has. Twilio has 4 routes; we cap at a generous bound that
+        # still catches the regression if the loop comes back.
+        tenant = Tenant.objects.create(name="ReachQueryCount")
+        cfg = _make_cfg(tenant, VoiceProvider.TWILIO)
+        call = _make_call(tenant, cfg)
+        for et in (
+            CallEventType.INITIATED,
+            CallEventType.RINGING,
+            CallEventType.RECORDING_COMPLETED,
+            CallEventType.COMPLETED,
+        ):
+            _make_event(call, et, timezone.now())
+        from voice.webhooks.reachability import probe_config
+
+        # 1 aggregate + 1 sample for any-event routes + up to 3 per
+        # filtered route that has a hit. Be generous; the goal is
+        # "constant, not N+1 per route count".
+        with django_assert_num_queries(10):
+            probe_config(cfg)
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Endpoint: POST /provider-configs/{id}/test-webhooks/

--- a/voice/urls.py
+++ b/voice/urls.py
@@ -13,6 +13,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from voice.views import (
+    AriHealthView,
     RecordingConsentViewSet,
     TenantVoiceAppViewSet,
     VoiceCallEventViewSet,
@@ -60,6 +61,8 @@ urlpatterns = [
     # REST API surface — mounted under ``/voice/v1/`` from the project
     # URL conf, so the effective prefix becomes ``/voice/v1/api/``.
     path("api/", include(router.urls)),
+    # B1 (#181): Asterisk ARI health probe used by the SIP wizard.
+    path("api/ari-health/", AriHealthView.as_view(), name="ari-health"),
     # ── Twilio ─────────────────────────────────────────────────────────
     path(
         "webhooks/twilio/<uuid:config_uuid>/call-status/",

--- a/voice/views.py
+++ b/voice/views.py
@@ -25,6 +25,7 @@ from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from tenants.models import TenantVoiceApp
 from voice.models import (
@@ -81,6 +82,20 @@ class VoiceProviderConfigViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(tenant=_user_tenant(self.request))
+
+    @action(detail=True, methods=["post"], url_path="test-webhooks")
+    def test_webhooks(self, request, pk=None):
+        """B4 (#184): probe webhook reachability for this config.
+
+        Returns one row per configured webhook URL with a status that
+        reflects whether the URL has received an event recently. The
+        first iteration is passive only — for active probes (provider
+        API → wait for callback) see ``voice/webhooks/reachability.py``.
+        """
+        from voice.webhooks.reachability import probe_config
+
+        config = self.get_object()
+        return Response(probe_config(config))
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -400,3 +415,56 @@ class RecordingConsentViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(tenant=_user_tenant(self.request))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Asterisk ARI health (B1 #181)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class AriHealthView(APIView):
+    """``GET /voice/v1/api/ari-health/`` — confirm Asterisk ARI is up.
+
+    Returns 200 with ``{ok: true, asterisk_version, endpoints_registered}``
+    on success, 503 with ``{ok: false, reason}`` when ARI is unreachable
+    or misconfigured. The frontend SIP gallery tile flips from greyed →
+    enabled based on this response.
+
+    The check is tenant-agnostic — ARI runs once per box, not per
+    tenant. We still gate on ``IsVoiceEnabledForTenant`` so unrelated
+    callers can't probe infrastructure state.
+    """
+
+    permission_classes = [IsAuthenticated, IsVoiceEnabledForTenant]
+
+    def get(self, request):
+        from voice.sip_config.ari_client import AriClient, AriError
+
+        client = AriClient()
+        if not client.base_url:
+            return Response(
+                {"ok": False, "reason": "ASTERISK_ARI_URL is not configured."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        try:
+            info = client.asterisk_info()
+            endpoints = client.list_endpoints()
+        except AriError as exc:
+            return Response(
+                {"ok": False, "reason": str(exc)},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        except Exception as exc:  # noqa: BLE001 — connection refused etc.
+            return Response(
+                {"ok": False, "reason": f"ARI unreachable: {exc}"},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        version = (info.get("system") or {}).get("version") or info.get("version") or "unknown"
+        return Response(
+            {
+                "ok": True,
+                "asterisk_version": version,
+                "endpoints_registered": len(endpoints),
+            }
+        )

--- a/voice/views.py
+++ b/voice/views.py
@@ -201,6 +201,26 @@ class VoiceCallViewSet(
         if tts_text:
             metadata["static_play"] = {"tts_text": tts_text}
 
+        # Stamp the provider's answer-webhook URL onto the call so
+        # ``voice.tasks.initiate_call`` can pass it as ``callback_url``
+        # to the adapter. Without this the task reads
+        # ``call.metadata["answer_callback_url"] == ""`` and Twilio
+        # rejects the request with an empty ``Url`` parameter.
+        _PROVIDER_ANSWER_ROUTE = {
+            "twilio": "voice:twilio-answer",
+            "plivo": "voice:plivo-answer",
+            "vonage": "voice:vonage-answer",
+            "telnyx": "voice:telnyx-event",
+            "exotel": "voice:exotel-passthru",
+        }
+        route_name = _PROVIDER_ANSWER_ROUTE.get(config.provider)
+        if route_name:
+            from django.urls import reverse
+
+            metadata["answer_callback_url"] = request.build_absolute_uri(
+                reverse(route_name, kwargs={"config_uuid": str(config.id)})
+            )
+
         # ``provider_call_id`` carries a placeholder until the adapter
         # replaces it with the real upstream SID. The (provider_config,
         # provider_call_id) unique constraint means concurrent dials to

--- a/voice/views.py
+++ b/voice/views.py
@@ -37,7 +37,12 @@ from voice.models import (
     VoiceRecording,
     VoiceTemplate,
 )
-from voice.permissions import IsAuthenticated, IsVoiceAdmin, IsVoiceEnabledForTenant
+from voice.permissions import (
+    HasVoicePermission,
+    IsAuthenticated,
+    IsVoiceAdmin,
+    IsVoiceEnabledForTenant,
+)
 from voice.serializers import (
     RecordingConsentSerializer,
     TenantVoiceAppSerializer,
@@ -95,7 +100,7 @@ class VoiceProviderConfigViewSet(viewsets.ModelViewSet):
         from voice.webhooks.reachability import probe_config
 
         config = self.get_object()
-        return Response(probe_config(config))
+        return Response(probe_config(config, request=request))
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -342,7 +347,18 @@ class VoiceRecordingViewSet(
     viewsets.GenericViewSet,
 ):
     serializer_class = VoiceRecordingSerializer
-    permission_classes = [IsAuthenticated, IsVoiceEnabledForTenant]
+    permission_classes = [IsAuthenticated, IsVoiceEnabledForTenant, HasVoicePermission]
+    # Differentiates play (list/retrieve return a short-TTL signed URL
+    # for inline playback) from download (the `download` action mints a
+    # caller-specified TTL — typically used for saving the audio locally).
+    # Maps to the voice.call.recording.* RBAC keys seeded in tenants/0019.
+    # (#185 review nit)
+    voice_required_permissions = {
+        "list": "voice.call.recording.play",
+        "retrieve": "voice.call.recording.play",
+        "download": "voice.call.recording.download",
+        "default": "voice.call.recording.play",
+    }
 
     def get_queryset(self):
         qs = (
@@ -481,10 +497,13 @@ class AriHealthView(APIView):
             )
 
         version = (info.get("system") or {}).get("version") or info.get("version") or "unknown"
-        return Response(
-            {
-                "ok": True,
-                "asterisk_version": version,
-                "endpoints_registered": len(endpoints),
-            }
-        )
+        body = {"ok": True, "asterisk_version": version}
+        # ``endpoints_registered`` is a box-wide count — Asterisk runs
+        # once per host across all tenants. Surfacing it to non-staff
+        # users would let one tenant infer another tenant's SIP
+        # onboarding activity by polling. Staff need the number for ops
+        # diagnostics; the wizard only needs the boolean "ARI is up".
+        # (#185 review)
+        if getattr(request.user, "is_staff", False):
+            body["endpoints_registered"] = len(endpoints)
+        return Response(body)

--- a/voice/webhooks/reachability.py
+++ b/voice/webhooks/reachability.py
@@ -1,0 +1,210 @@
+"""B4 (#184): webhook reachability probes.
+
+Per-provider answer to "is my webhook actually being hit?". The first
+iteration is passive only — we compute the last time each webhook URL
+for a given ``VoiceProviderConfig`` received an event by looking at
+``VoiceCallEvent.occurred_at`` joined back to the config. That answers
+the day-to-day question "my webhook hasn't fired in a week, is it
+broken?" without any provider-side coordination.
+
+The endpoint shape is designed so the active-probe path (asking the
+provider to fire a test webhook against our URL via a correlation ID
+and short-lived Redis flag) can be added later without changing the
+response schema. Until then, every provider returns ``probe_type:
+"passive"``.
+
+Schema:
+
+```
+{
+  "config_id": "<uuid>",
+  "provider": "twilio",
+  "probe_type": "passive",
+  "results": [
+    {
+      "label": "call-status",
+      "url": "https://example.com/voice/v1/webhooks/twilio/<uuid>/call-status/",
+      "status": "passive_recent" | "passive_stale" | "passive_never",
+      "last_received_at": "2026-05-18T..." | null,
+      "sample_call_id": "<uuid>" | null
+    },
+    ...
+  ]
+}
+```
+
+Status thresholds (configurable via ``settings``):
+
+  * ``passive_recent`` — last event within the last 15 minutes
+  * ``passive_stale``  — last event older than 15 minutes
+  * ``passive_never``  — no event ever for this URL on this config
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Optional
+from urllib.parse import urljoin
+
+from django.conf import settings
+from django.urls import reverse
+from django.utils import timezone
+
+from voice.constants import VoiceProvider
+from voice.models import VoiceCallEvent, VoiceProviderConfig
+
+PASSIVE_RECENT_WINDOW = timedelta(minutes=15)
+
+
+@dataclass(frozen=True)
+class WebhookRoute:
+    """One named webhook entry-point for a provider.
+
+    ``label`` is a stable identifier the frontend renders next to each
+    row (e.g. "call-status", "answer"). ``url_name`` is the Django URL
+    name in ``voice/urls.py``.
+    """
+
+    label: str
+    url_name: str
+
+
+# Each provider exposes a fixed set of webhook URLs; SIP is intentionally
+# omitted because it has no HTTP webhooks (events arrive via the ARI
+# WebSocket consumer, not an HTTP callback).
+WEBHOOK_ROUTES_BY_PROVIDER: dict[str, list[WebhookRoute]] = {
+    VoiceProvider.TWILIO: [
+        WebhookRoute("call-status", "voice:twilio-call-status"),
+        WebhookRoute("answer", "voice:twilio-answer"),
+        WebhookRoute("gather", "voice:twilio-gather"),
+        WebhookRoute("recording-status", "voice:twilio-recording-status"),
+    ],
+    VoiceProvider.PLIVO: [
+        WebhookRoute("call-status", "voice:plivo-call-status"),
+        WebhookRoute("answer", "voice:plivo-answer"),
+        WebhookRoute("recording", "voice:plivo-recording"),
+    ],
+    VoiceProvider.VONAGE: [
+        WebhookRoute("event", "voice:vonage-event"),
+        WebhookRoute("answer", "voice:vonage-answer"),
+    ],
+    VoiceProvider.TELNYX: [
+        WebhookRoute("event", "voice:telnyx-event"),
+    ],
+    VoiceProvider.EXOTEL: [
+        WebhookRoute("status", "voice:exotel-status"),
+        WebhookRoute("passthru", "voice:exotel-passthru"),
+    ],
+}
+
+
+def _public_base_url() -> str:
+    """Best-effort guess at the public origin for webhook URLs.
+
+    Falls back to a placeholder host so the URL is still parseable when
+    the project hasn't set ``PUBLIC_BASE_URL`` — the frontend cares
+    about the *path*, not the host, in the passive case.
+    """
+    return getattr(settings, "PUBLIC_BASE_URL", "") or "https://example.invalid/"
+
+
+def _absolute_url(url_name: str, config_uuid: str) -> str:
+    path = reverse(url_name, kwargs={"config_uuid": config_uuid})
+    return urljoin(_public_base_url(), path)
+
+
+def _routes_for(provider: str) -> list[WebhookRoute]:
+    return WEBHOOK_ROUTES_BY_PROVIDER.get(provider, [])
+
+
+def _classify(last_received_at) -> str:
+    if last_received_at is None:
+        return "passive_never"
+    if timezone.now() - last_received_at <= PASSIVE_RECENT_WINDOW:
+        return "passive_recent"
+    return "passive_stale"
+
+
+def _last_event_for_route(config: VoiceProviderConfig, label: str) -> tuple[Optional[object], Optional[str]]:
+    """Return ``(occurred_at, sample_call_id)`` for the most recent event
+    on a config that we can attribute to *label*.
+
+    The route-label mapping to ``VoiceCallEvent.event_type`` is coarse —
+    we do not record which webhook URL fired which event, only the
+    canonical event type. For the passive probe this is good enough:
+
+      * "call-status" / "event" / "status" route → any non-recording event
+      * "answer" route → INITIATED or RINGING events (the answer hook
+        is invoked at call setup)
+      * "gather" route → DTMF_RECEIVED / SPEECH_RECEIVED events
+      * "recording-status" / "recording" / "passthru" route → RECORDING_*
+        events
+
+    For providers like Telnyx that have a single event webhook, all
+    events count toward freshness — exactly what the user wants.
+    """
+    from voice.constants import CallEventType
+
+    label_filters: dict[str, list[str]] = {
+        "call-status": [],  # any event
+        "event": [],
+        "status": [],
+        "answer": [CallEventType.INITIATED, CallEventType.RINGING],
+        "gather": [CallEventType.DTMF, CallEventType.SPEECH],
+        "recording-status": [
+            CallEventType.RECORDING_STARTED,
+            CallEventType.RECORDING_COMPLETED,
+        ],
+        "recording": [
+            CallEventType.RECORDING_STARTED,
+            CallEventType.RECORDING_COMPLETED,
+        ],
+        "passthru": [
+            CallEventType.RECORDING_STARTED,
+            CallEventType.RECORDING_COMPLETED,
+        ],
+    }
+    events = VoiceCallEvent.objects.filter(call__provider_config=config).order_by("-occurred_at")
+    type_filter = label_filters.get(label)
+    if type_filter:
+        events = events.filter(event_type__in=type_filter)
+    last = events.values("occurred_at", "call_id").first()
+    if not last:
+        return None, None
+    return last["occurred_at"], str(last["call_id"])
+
+
+def probe_config(config: VoiceProviderConfig) -> dict:
+    """Run the passive reachability probe for *config*.
+
+    Returns the response dict the API surface emits verbatim.
+    """
+    routes = _routes_for(config.provider)
+    results: list[dict] = []
+    config_uuid = str(config.id)
+    for route in routes:
+        last_at, sample_call_id = _last_event_for_route(config, route.label)
+        results.append(
+            {
+                "label": route.label,
+                "url": _absolute_url(route.url_name, config_uuid),
+                "status": _classify(last_at),
+                "last_received_at": last_at.isoformat() if last_at else None,
+                "sample_call_id": sample_call_id,
+            }
+        )
+    return {
+        "config_id": config_uuid,
+        "provider": config.provider,
+        "probe_type": "passive",
+        "results": results,
+    }
+
+
+__all__ = [
+    "PASSIVE_RECENT_WINDOW",
+    "WEBHOOK_ROUTES_BY_PROVIDER",
+    "WebhookRoute",
+    "probe_config",
+]

--- a/voice/webhooks/reachability.py
+++ b/voice/webhooks/reachability.py
@@ -26,18 +26,25 @@ Schema:
       "url": "https://example.com/voice/v1/webhooks/twilio/<uuid>/call-status/",
       "status": "passive_recent" | "passive_stale" | "passive_never",
       "last_received_at": "2026-05-18T..." | null,
-      "sample_call_id": "<uuid>" | null
+      "sample_call_id": "<uuid>" | null,
+      "inferred_from": "any_event" | "event_type"
     },
     ...
   ]
 }
 ```
 
-Status thresholds (configurable via ``settings``):
+Status thresholds:
 
   * ``passive_recent`` — last event within the last 15 minutes
   * ``passive_stale``  — last event older than 15 minutes
   * ``passive_never``  — no event ever for this URL on this config
+
+``inferred_from`` ("any_event" vs "event_type") flags how the freshness
+was derived. For providers with a single webhook URL (Telnyx, Exotel's
+``status``), the row covers all events so we tag it ``any_event`` — the
+UI can render a "best-effort" hint instead of pretending the freshness
+is per-route. (#185 review)
 """
 
 from __future__ import annotations
@@ -48,6 +55,7 @@ from typing import Optional
 from urllib.parse import urljoin
 
 from django.conf import settings
+from django.db.models import Max
 from django.urls import reverse
 from django.utils import timezone
 
@@ -99,54 +107,22 @@ WEBHOOK_ROUTES_BY_PROVIDER: dict[str, list[WebhookRoute]] = {
 }
 
 
-def _public_base_url() -> str:
-    """Best-effort guess at the public origin for webhook URLs.
-
-    Falls back to a placeholder host so the URL is still parseable when
-    the project hasn't set ``PUBLIC_BASE_URL`` — the frontend cares
-    about the *path*, not the host, in the passive case.
-    """
-    return getattr(settings, "PUBLIC_BASE_URL", "") or "https://example.invalid/"
-
-
-def _absolute_url(url_name: str, config_uuid: str) -> str:
-    path = reverse(url_name, kwargs={"config_uuid": config_uuid})
-    return urljoin(_public_base_url(), path)
+# Each route maps to a list of canonical ``CallEventType`` values it
+# represents. An empty list means "any event" — the route covers a
+# single webhook URL that receives all events, so its freshness is
+# inferred from the latest event of any type. ``inferred_from`` in the
+# response surfaces this distinction. Filled in lazily on first probe
+# to avoid importing ``CallEventType`` at module load.
+_ROUTE_EVENT_TYPES: dict[str, list[str]] = {}
 
 
-def _routes_for(provider: str) -> list[WebhookRoute]:
-    return WEBHOOK_ROUTES_BY_PROVIDER.get(provider, [])
-
-
-def _classify(last_received_at) -> str:
-    if last_received_at is None:
-        return "passive_never"
-    if timezone.now() - last_received_at <= PASSIVE_RECENT_WINDOW:
-        return "passive_recent"
-    return "passive_stale"
-
-
-def _last_event_for_route(config: VoiceProviderConfig, label: str) -> tuple[Optional[object], Optional[str]]:
-    """Return ``(occurred_at, sample_call_id)`` for the most recent event
-    on a config that we can attribute to *label*.
-
-    The route-label mapping to ``VoiceCallEvent.event_type`` is coarse —
-    we do not record which webhook URL fired which event, only the
-    canonical event type. For the passive probe this is good enough:
-
-      * "call-status" / "event" / "status" route → any non-recording event
-      * "answer" route → INITIATED or RINGING events (the answer hook
-        is invoked at call setup)
-      * "gather" route → DTMF_RECEIVED / SPEECH_RECEIVED events
-      * "recording-status" / "recording" / "passthru" route → RECORDING_*
-        events
-
-    For providers like Telnyx that have a single event webhook, all
-    events count toward freshness — exactly what the user wants.
-    """
+def _route_event_types() -> dict[str, list[str]]:
+    global _ROUTE_EVENT_TYPES
+    if _ROUTE_EVENT_TYPES:
+        return _ROUTE_EVENT_TYPES
     from voice.constants import CallEventType
 
-    label_filters: dict[str, list[str]] = {
+    _ROUTE_EVENT_TYPES = {
         "call-status": [],  # any event
         "event": [],
         "status": [],
@@ -165,35 +141,116 @@ def _last_event_for_route(config: VoiceProviderConfig, label: str) -> tuple[Opti
             CallEventType.RECORDING_COMPLETED,
         ],
     }
-    events = VoiceCallEvent.objects.filter(call__provider_config=config).order_by("-occurred_at")
-    type_filter = label_filters.get(label)
-    if type_filter:
-        events = events.filter(event_type__in=type_filter)
-    last = events.values("occurred_at", "call_id").first()
-    if not last:
-        return None, None
-    return last["occurred_at"], str(last["call_id"])
+    return _ROUTE_EVENT_TYPES
 
 
-def probe_config(config: VoiceProviderConfig) -> dict:
+def _absolute_url(request, url_name: str, config_uuid: str) -> str:
+    """Build the public URL for a webhook route.
+
+    Prefers ``request.build_absolute_uri()`` (uses the inbound Host
+    header — always reflects how the caller reached us). Falls back to
+    ``PUBLIC_BASE_URL`` when no request is available (e.g. called from
+    a Celery task). The legacy ``example.invalid`` fallback was loud
+    on purpose but confusing in operator output — drop it for an empty
+    base path instead. (#185 review)
+    """
+    path = reverse(url_name, kwargs={"config_uuid": config_uuid})
+    if request is not None:
+        return request.build_absolute_uri(path)
+    base = getattr(settings, "PUBLIC_BASE_URL", "") or ""
+    return urljoin(base.rstrip("/") + "/", path.lstrip("/")) if base else path
+
+
+def _routes_for(provider: str) -> list[WebhookRoute]:
+    return WEBHOOK_ROUTES_BY_PROVIDER.get(provider, [])
+
+
+def _classify(last_received_at) -> str:
+    if last_received_at is None:
+        return "passive_never"
+    if timezone.now() - last_received_at <= PASSIVE_RECENT_WINDOW:
+        return "passive_recent"
+    return "passive_stale"
+
+
+def probe_config(config: VoiceProviderConfig, request=None) -> dict:
     """Run the passive reachability probe for *config*.
 
-    Returns the response dict the API surface emits verbatim.
+    Returns the response dict the API surface emits verbatim. Issues
+    one aggregate query that finds ``(event_type, max(occurred_at))``
+    per type, then projects per-route freshness in Python — replacing
+    the previous N+1 path that ran one ``ORDER BY occurred_at DESC
+    LIMIT 1`` per route. Pairs with the composite index on
+    ``VoiceCallEvent`` added in migration ``0006``. (#185 review)
     """
     routes = _routes_for(config.provider)
-    results: list[dict] = []
     config_uuid = str(config.id)
+
+    # Single query: for this config, find latest occurrence of each
+    # event type, plus a sample call id for that latest occurrence.
+    # We can't pull sample_call_id in the GROUP BY without a window
+    # function, so do a second cheap query keyed by the (event_type,
+    # occurred_at) tuples we found.
+    per_type_max = dict(
+        VoiceCallEvent.objects.filter(call__provider_config=config)
+        .values_list("event_type")
+        .annotate(latest=Max("occurred_at"))
+        .values_list("event_type", "latest")
+    )
+    if per_type_max:
+        latest_overall = max(per_type_max.values())
+        sample_for_latest = (
+            VoiceCallEvent.objects.filter(
+                call__provider_config=config,
+                occurred_at=latest_overall,
+            )
+            .values_list("event_type", "call_id")
+            .first()
+        )
+    else:
+        latest_overall = None
+        sample_for_latest = None
+
+    route_event_types = _route_event_types()
+    results: list[dict] = []
     for route in routes:
-        last_at, sample_call_id = _last_event_for_route(config, route.label)
+        filter_types = route_event_types.get(route.label, [])
+        if filter_types:
+            inferred_from = "event_type"
+            last_at = None
+            sample_call_id: Optional[str] = None
+            for et in filter_types:
+                t = per_type_max.get(et)
+                if t and (last_at is None or t > last_at):
+                    last_at = t
+            if last_at is not None:
+                row = (
+                    VoiceCallEvent.objects.filter(
+                        call__provider_config=config,
+                        event_type__in=filter_types,
+                        occurred_at=last_at,
+                    )
+                    .values_list("call_id")
+                    .first()
+                )
+                if row:
+                    sample_call_id = str(row[0])
+        else:
+            inferred_from = "any_event"
+            last_at = latest_overall
+            sample_call_id = str(sample_for_latest[1]) if sample_for_latest else None
+
         results.append(
             {
                 "label": route.label,
-                "url": _absolute_url(route.url_name, config_uuid),
+                "url": _absolute_url(request, route.url_name, config_uuid),
                 "status": _classify(last_at),
                 "last_received_at": last_at.isoformat() if last_at else None,
                 "sample_call_id": sample_call_id,
+                "inferred_from": inferred_from,
             }
         )
+
     return {
         "config_id": config_uuid,
         "provider": config.provider,


### PR DESCRIPTION
## Summary

Four small backend tickets that unblock the frontend SIP wizard work in `jain-t/jina-connect-web`. Ships as one PR so CI runs migrations + tests against the combined diff.

- **B1 [#181](https://github.com/JINA-CODE-SYSTEMS/jina-connect-unified-cpaas/issues/181)** — `GET /voice/v1/api/ari-health/` endpoint + Asterisk + chan_pjsip deploy runbook. The Asterisk install on `django-instance-2` is ops work and lives outside this PR (see `docs/deployment/asterisk.mdx`).
- **B2 [#182](https://github.com/JINA-CODE-SYSTEMS/jina-connect-unified-cpaas/issues/182)** — 18 `voice.*` RBAC permission keys + per-role grants + idempotent data migration. `IsVoiceAdmin` now checks `voice.provider.edit` instead of matching role names; staff bypass preserved.
- **B3 [#183](https://github.com/JINA-CODE-SYSTEMS/jina-connect-unified-cpaas/issues/183)** — Partial unique constraints on `VoiceProviderConfig` for `is_default_outbound=True` / `is_default_inbound=True` per tenant, plus serializer-level transactional demotion so the REST API auto-flips the existing default.
- **B4 [#184](https://github.com/JINA-CODE-SYSTEMS/jina-connect-unified-cpaas/issues/184)** — `POST /voice/v1/api/provider-configs/{id}/test-webhooks/` passive reachability probe (active-probe path reserved in the schema for a future iteration).

## What's NOT in the PR

- The actual `apt install asterisk` + systemd + GCP firewall changes on `django-instance-2`. That's ops work, not code; it's documented in `docs/deployment/asterisk.mdx` and will be applied separately.

## Test plan

- [ ] CI green: `voice/tests/test_default_flag_mutex.py` (B3)
- [ ] CI green: `voice/tests/test_rbac_voice_keys.py` (B2)
- [ ] CI green: `voice/tests/test_ari_health.py` (B1)
- [ ] CI green: `voice/tests/test_webhook_reachability.py` (B4)
- [ ] Existing voice REST tests still pass with the new `IsVoiceAdmin` (owner-role admin client and agent-role agent client both behave the same as before since the seed grants match the legacy role-name list).
- [ ] Migrations apply cleanly: `voice 0005`, `tenants 0019`.

## Migrations

- `voice/0005_voiceproviderconfig_default_flag_mutex` — adds two partial unique indexes. Postgres only (the existing model already relies on `Q(...)` conditions).
- `tenants/0019_rbac_add_voice_permissions` — data migration; idempotent via `get_or_create`. Reverse migration deletes the voice rows so down-path is clean.

## Closes

Closes #181, #182, #183, #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)