### PR TITLE
feat(ctwa): full CTWA backend bundle — #188 #189 #191 #192 #194 #195 #196 #197 #198

### DIFF
--- a/chat_flow/apps.py
+++ b/chat_flow/apps.py
@@ -5,3 +5,15 @@ class ChatFlowConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "chat_flow"
     verbose_name = "Chat Flow Management"
+
+    def ready(self) -> None:
+        # Importing the trigger-types package populates the registry
+        # via each module's ``@register_trigger`` decorator. Done here
+        # (not at the top of ``chat_flow.triggers``) to avoid hitting
+        # the Django app registry before it's ready.
+        try:
+            import chat_flow.triggers.types  # noqa: F401
+        except Exception:  # pragma: no cover — defensive
+            import logging
+
+            logging.getLogger(__name__).exception("[chat_flow] failed to load trigger types at boot")

--- a/chat_flow/migrations/0008_chatflow_triggers.py
+++ b/chat_flow/migrations/0008_chatflow_triggers.py
@@ -1,0 +1,24 @@
+# #188: event-trigger declarative list on ChatFlow. Empty default keeps
+# all existing flows on the legacy contact-assignment invocation path.
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("chat_flow", "0007_chatflow_platform"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="chatflow",
+            name="triggers",
+            field=models.JSONField(
+                blank=True,
+                default=list,
+                help_text=(
+                    "List of {type, config} entries that auto-spawn this flow on "
+                    "matching inbound events. Empty = legacy assignment-only flow."
+                ),
+            ),
+        ),
+    ]

--- a/chat_flow/models.py
+++ b/chat_flow/models.py
@@ -137,6 +137,21 @@ class ChatFlow(BaseTenantModelForFilterUser):
         help_text="Platform this flow targets. Determines which node types are valid.",
     )
 
+    # Event triggers — declarative list of {type, config} entries that
+    # auto-spawn this flow when a matching inbound event arrives. Empty
+    # list (the default) preserves the legacy contact-assignment path
+    # untouched; flows opt in to event-based invocation by populating
+    # this field. Validated at save time via
+    # ``chat_flow.triggers.validators.validate_trigger_list`` (#188).
+    triggers = models.JSONField(
+        default=list,
+        blank=True,
+        help_text=(
+            "List of {type, config} entries that auto-spawn this flow on "
+            "matching inbound events. Empty = legacy assignment-only flow."
+        ),
+    )
+
     class Meta:
         verbose_name = "Chat Flow"
         verbose_name_plural = "Chat Flows"
@@ -157,6 +172,11 @@ class ChatFlow(BaseTenantModelForFilterUser):
         errors = validate_flow_for_platform(self.flow_data, self.platform)
         if errors:
             raise ValidationError({"flow_data": errors})
+        # Validate ``triggers`` payload — unknown type / bad config /
+        # duplicate within one flow (#188).
+        from chat_flow.triggers.validators import validate_trigger_list
+
+        validate_trigger_list(self.triggers)
 
     def save(self, *args, **kwargs):
         # Run our custom ``clean()`` (registry validation against

--- a/chat_flow/triggers/README.md
+++ b/chat_flow/triggers/README.md
@@ -1,0 +1,189 @@
+# `chat_flow.triggers` — event-trigger subsystem (#188)
+
+Lets a `ChatFlow` declare *when* it auto-spawns instead of relying on
+manual contact-assignment (`contact.assigned_to_type=CHATFLOW`). The
+substrate is channel-agnostic — CTWA, inbound voice, SMS keywords,
+RCS suggestion-taps, and Telegram commands all hook the same registry.
+
+## Architecture in 30 seconds
+
+```
+[channel webhook]  ─parse─▶  emit(TriggerEvent)  ─▶  dispatch(event)
+                                                         │
+                                          ┌──────────────┴────────────┐
+                                          │ For each active flow:     │
+                                          │   For each trigger entry: │
+                                          │     trigger.matches(...)? │
+                                          │       └─▶ queue session   │
+                                          └───────────────────────────┘
+```
+
+* `TriggerEvent` — frozen dataclass; the normalised cross-channel payload.
+* `BaseTrigger` — ABC every trigger type subclasses.
+* `@register_trigger("name")` — module-level decorator. Mirrors
+  `voice.adapters.registry.register_voice_adapter` style.
+* `dispatch(event)` — finds matching flows, queues
+  `start_chatflow_session_task` via Celery, returns the number of
+  spawns. Idempotent across webhook replays (Redis SETNX, 24h TTL).
+
+## ChatFlow.triggers config shape
+
+```jsonc
+[
+  {
+    "type": "inbound_keyword_match",
+    "config": {
+      "keywords": ["sales", "pricing"],
+      "channel": "wa",        // optional; "any" or null = all channels
+      "case_sensitive": false // default false
+    }
+  },
+  {
+    "type": "ctwa_referral_received",
+    "config": {
+      "campaign_ids": "any"   // or ["<uuid>", "<uuid>", ...]
+    }
+  }
+]
+```
+
+Validated at save time via `chat_flow.triggers.validators`. Unknown
+trigger types, malformed config, and within-flow duplicates all raise
+`ValidationError` on `ChatFlow.save()`.
+
+## Adding a new trigger type
+
+1. Create `chat_flow/triggers/types/<your_name>.py`.
+2. Declare a Pydantic config model. This drives save-time validation
+   and the frontend introspection endpoint.
+3. Subclass `BaseTrigger`, implement `matches(event, config) -> bool`.
+   * Pure function. No DB writes. Never raise.
+   * Return `False` on partial / missing data; never raise.
+4. Decorate the class with `@register_trigger("<your_name>")`.
+5. Import the module from `chat_flow/triggers/types/__init__.py`.
+6. Add tests under `chat_flow/triggers/tests/`.
+7. Document any `event.extra` fields the trigger reads (below).
+
+Skeleton:
+
+```python
+from pydantic import BaseModel
+from chat_flow.triggers.base import BaseTrigger, TriggerEvent
+from chat_flow.triggers.registry import register_trigger
+
+
+class MyConfig(BaseModel):
+    threshold: int = 1
+
+
+@register_trigger("my_trigger")
+class MyTrigger(BaseTrigger):
+    config_model = MyConfig
+
+    def matches(self, event: TriggerEvent, config: dict) -> bool:
+        # Read event.extra fields you need; return True/False.
+        return bool(event.body_text and len(event.body_text) >= config.get("threshold", 1))
+```
+
+## Adding a new channel emission point
+
+Drop these four lines into the channel's inbound webhook processor,
+right after the inbound row is persisted:
+
+```python
+from chat_flow.triggers import TriggerEvent, emit
+
+emit(TriggerEvent(
+    tenant_id=tenant.id,
+    channel="<your_channel>",       # one of: wa | sms | voice | rcs | telegram
+    contact_id=contact.id,
+    inbound_row_id=str(message.pk),
+    inbound_row_model="<app>.<Model>",
+    body_text=text_or_none,
+    received_at=timezone.now().isoformat(),
+    extra={...},                    # channel-specific fields; see below
+))
+```
+
+Wrap the call in `try/except` and log on failure — triggers are an
+additive routing layer; a subsystem hiccup must never break inbound
+message ingestion.
+
+Currently wired:
+
+| Channel | Site | Inbound row |
+|---|---|---|
+| `wa` | [`wa/tasks.py`](../../wa/tasks.py) — after `_handle_chatflow_routing()` | `team_inbox.Messages` |
+| `voice` | [`voice/tasks.py:process_call_status`](../../voice/tasks.py) — on INITIATED / RINGING for INBOUND calls | `voice.VoiceCall` |
+
+Pending (each gets its own follow-on issue):
+
+| Channel | Why deferred |
+|---|---|
+| `sms` | Inbound persistence is spread across webhook handlers; needs its own consolidation pass. |
+| `rcs` | Same. |
+| `telegram` | Same; multiple inbound paths (text, edited_message, reaction) need uniform emit. |
+
+## `event.extra` contract by channel
+
+Triggers MUST tolerate missing keys (the contract is "best-effort enrichment").
+
+### WhatsApp (`channel="wa"`)
+
+| Key | Type | Notes |
+|---|---|---|
+| `wa_webhook_event_id` | str | Source webhook row PK; for audit. |
+| `external_message_id` | str | Provider-assigned message id. |
+| `referral_source_type` | str | `"ad"` / `"post"` — present when CTWA referral is in the payload. Populated by #192. |
+| `referral_source_id` | str | Meta ad ID. |
+| `referral_source_url` | str | |
+| `referral_headline` | str | |
+| `referral_body` | str | |
+| `referral_media_type` | str | `"image"` / `"video"` / `""`. |
+| `referral_media_url` | str | |
+| `referral_ctwa_clid` | str \| null | Critical for CAPI match quality; not all BSPs expose it. |
+| `campaign_id` | uuid \| null | CTWA campaign resolved from `referral_source_id`. Populated by #194 ingestion. Null = orphan ad. |
+
+### Voice (`channel="voice"`)
+
+| Key | Type | Notes |
+|---|---|---|
+| `provider_call_id` | str | Twilio CallSid / Plivo CallUUID / SIP Call-ID. |
+| `from_number` | str | E.164. |
+| `to_number` | str | E.164. |
+| `event_type` | str | `"initiated"` or `"ringing"` (only these fire emit). |
+
+## Idempotency guarantee
+
+`dispatch(event)` claims `chatflow:trigger:dispatch:<tenant>:<channel>:<inbound_row_id>`
+via Redis `SET NX EX=86400` before iterating flows. Webhook replays
+within 24h are silent no-ops. Outside that window — extremely rare —
+a duplicate session is preferable to a silent drop.
+
+Redis-down behaviour is **fail open** (proceed with dispatch). The
+alternative is silent ingestion drops on infrastructure hiccups,
+which is the strictly worse failure mode.
+
+## Anti-patterns
+
+* **No DB writes in `matches()`.** It runs once per flow per event;
+  any side effect ships duplicates as soon as a tenant has two
+  matching flows.
+* **Never raise from `matches()`.** The dispatcher catches and logs,
+  but exceptions add noise and hide trigger-type bugs.
+* **Don't mutate `event` or `config`.** Both are shared across
+  per-flow iterations within a single dispatch.
+* **Don't read tenant data inside `matches()`.** Anything that needs
+  tenant context should go on `event.extra` at emission time.
+
+## Introspection endpoint
+
+Frontend uses `GET /chat_flow/api/v1/triggers/types/` to render the
+trigger-config form in the flow builder. Response is a list of
+`{type_name, config_schema}` where `config_schema` is the
+Pydantic-generated JSON Schema for that trigger's config model.
+
+Backwards-compatibility contract: never change a `type_name` after a
+trigger ships. Removing a `type_name` requires a deprecation path
+(stop registering, but tolerate the type in dispatcher; flow validator
+warns instead of failing).

--- a/chat_flow/triggers/__init__.py
+++ b/chat_flow/triggers/__init__.py
@@ -1,0 +1,49 @@
+"""Event-trigger subsystem for chat_flow (#188).
+
+Bridges inbound events (WA message, voice call, SMS, RCS, Telegram)
+to flow invocation. Channel-agnostic substrate with a registry of
+named trigger types. Each channel's webhook processor emits a
+normalised ``TriggerEvent`` after persisting the inbound row; the
+dispatcher fans out to every active flow whose configured trigger
+matches.
+
+Public surface:
+
+  * :class:`TriggerEvent` — the normalised cross-channel payload.
+  * :class:`BaseTrigger` — ABC every trigger subclasses.
+  * :func:`register_trigger` — decorator used by trigger modules.
+  * :func:`emit` — single entry point for channel processors.
+  * :func:`list_trigger_types` — used by the frontend introspection
+    endpoint to render the trigger-config panel.
+"""
+
+from __future__ import annotations
+
+from chat_flow.triggers.base import BaseTrigger, TriggerEvent
+from chat_flow.triggers.dispatcher import dispatch
+from chat_flow.triggers.registry import (
+    get_trigger_cls,
+    list_trigger_types,
+    register_trigger,
+)
+
+
+def emit(event: TriggerEvent) -> int:
+    """Public entry point for channel webhook processors.
+
+    Returns the number of flow sessions queued for this event. Safe to
+    call from synchronous code paths — the dispatcher itself never
+    raises and is idempotent across replays (Redis SETNX keyed on
+    ``(tenant, channel, inbound_row_id)`` with a 24h TTL).
+    """
+    return dispatch(event)
+
+
+__all__ = [
+    "BaseTrigger",
+    "TriggerEvent",
+    "emit",
+    "register_trigger",
+    "get_trigger_cls",
+    "list_trigger_types",
+]

--- a/chat_flow/triggers/base.py
+++ b/chat_flow/triggers/base.py
@@ -1,0 +1,145 @@
+"""Base classes for the chat_flow event-trigger subsystem (#188).
+
+The substrate is intentionally small:
+
+  * :class:`TriggerEvent` is a frozen dataclass — the normalised
+    cross-channel payload a webhook processor emits after persisting
+    an inbound row.
+
+  * :class:`BaseTrigger` is the ABC every concrete trigger type
+    subclasses. Subclasses declare:
+
+      - ``type_name`` (set by ``@register_trigger``)
+      - ``config_model`` (a Pydantic model; validates the per-flow
+        config payload at save time)
+      - ``matches(event, config) -> bool`` (pure function; never
+        writes to the DB, never raises)
+
+Idempotency helpers live here too so trigger implementations can stay
+unaware of Redis. The dispatcher claims a SETNX lock keyed on
+``(tenant, channel, inbound_row_id)`` before iterating flows; replays
+of the same webhook are a no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+Channel = Literal["wa", "sms", "voice", "rcs", "telegram"]
+
+
+@dataclass(frozen=True)
+class TriggerEvent:
+    """A normalised inbound event that may match one or more triggers.
+
+    Channel-specific fields go into ``extra`` so the trigger subsystem
+    stays channel-agnostic. Triggers that read channel-specific data
+    (e.g. CTWA ``referral_source_id`` on a WA message) read from
+    ``extra`` by an agreed key — see ``triggers/README.md``.
+
+    ``inbound_row_id`` is a string because not every inbound model
+    uses integer PKs (voice uses UUIDs, others use BIGSERIAL). The
+    ``inbound_row_model`` field disambiguates the source so support
+    can correlate a dispatched session back to its triggering event.
+    """
+
+    tenant_id: int
+    channel: Channel
+    contact_id: int
+    inbound_row_id: str
+    inbound_row_model: str
+    body_text: str | None
+    received_at: str  # ISO8601; used inside the idempotency key
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+class BaseTrigger:
+    """Abstract base for every registered trigger type.
+
+    Subclasses MUST set :attr:`config_model` (a Pydantic ``BaseModel``
+    subclass) and implement :meth:`matches`. The :attr:`type_name`
+    attribute is stamped by ``@register_trigger`` at decorator time.
+
+    Implementations are pure functions of ``(event, config) -> bool``:
+
+      * MUST NOT write to the DB.
+      * MUST NOT raise. Return ``False`` on missing / partial data.
+      * MUST NOT mutate ``event`` or ``config``.
+
+    Violating any of the above breaks dispatcher idempotency or
+    cross-trigger isolation.
+    """
+
+    # Stamped by @register_trigger. Subclasses should leave this alone.
+    type_name: ClassVar[str] = ""
+
+    # Required: subclass declares its config schema as a Pydantic model.
+    # Used both for save-time validation of ChatFlow.triggers entries
+    # and for the frontend introspection endpoint.
+    config_model: ClassVar[type[BaseModel]]
+
+    def matches(self, event: TriggerEvent, config: dict) -> bool:  # pragma: no cover
+        raise NotImplementedError
+
+
+def make_dispatch_key(event: TriggerEvent) -> str:
+    """Return the Redis idempotency key for *event*.
+
+    Exposed so tests can mock or assert key shape. Format is stable —
+    operators may grep for it in Redis dumps.
+    """
+    return f"chatflow:trigger:dispatch:{event.tenant_id}:{event.channel}:{event.inbound_row_id}"
+
+
+def claim_dispatch(event: TriggerEvent, ttl_seconds: int = 86400) -> bool:
+    """Atomically claim the right to dispatch *event*. Returns True the
+    first time, False on every subsequent call within the TTL window.
+
+    24h covers any plausible webhook replay window; events older than
+    that won't reach dispatch via the normal channel paths anyway. If
+    Redis is unreachable, fail open (return True) — the alternative is
+    to silently drop events on infrastructure hiccups.
+    """
+    try:
+        from django_redis import get_redis_connection
+
+        r = get_redis_connection("default")
+        return bool(r.set(make_dispatch_key(event), "1", nx=True, ex=ttl_seconds))
+    except Exception as exc:  # noqa: BLE001 — broad: any Redis failure
+        logger.warning("[chat_flow.triggers] Redis claim failed (failing open): %s", exc)
+        return True
+
+
+def serialize_event(event: TriggerEvent) -> dict[str, Any]:
+    """Make a JSON-serialisable dict copy of *event* for Celery payloads.
+
+    Frozen dataclasses don't serialise through Django's default JSON
+    encoder unless we project to a dict; this helper centralises that
+    so all dispatch sites produce the same shape.
+    """
+    return {
+        "tenant_id": event.tenant_id,
+        "channel": event.channel,
+        "contact_id": event.contact_id,
+        "inbound_row_id": event.inbound_row_id,
+        "inbound_row_model": event.inbound_row_model,
+        "body_text": event.body_text,
+        "received_at": event.received_at,
+        "extra": dict(event.extra),
+    }
+
+
+__all__ = [
+    "BaseTrigger",
+    "Channel",
+    "TriggerEvent",
+    "claim_dispatch",
+    "make_dispatch_key",
+    "serialize_event",
+]

--- a/chat_flow/triggers/dispatcher.py
+++ b/chat_flow/triggers/dispatcher.py
@@ -1,0 +1,126 @@
+"""Trigger dispatcher for chat_flow (#188).
+
+Given a normalised :class:`TriggerEvent`, find every active
+:class:`ChatFlow` in the event's tenant whose ``triggers`` config
+matches, and queue a session spawn via the existing
+``start_chatflow_session_task`` Celery task. Idempotent across
+webhook replays via :func:`chat_flow.triggers.base.claim_dispatch`.
+
+Design contracts:
+
+  * A trigger that raises inside ``matches()`` is logged and skipped.
+    A single misbehaving trigger never breaks dispatch for the others.
+
+  * At most one session is queued per flow per event — the first
+    matching trigger entry wins. Multiple flows can still match the
+    same event independently.
+
+  * Dispatcher never writes to the DB itself (no audit table). The
+    spawned ``UserChatFlowSession`` carries trigger context inside its
+    ``context_data`` JSON; that's the audit trail.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from chat_flow.triggers.base import (
+    TriggerEvent,
+    claim_dispatch,
+    serialize_event,
+)
+from chat_flow.triggers.registry import _REGISTRY
+
+if TYPE_CHECKING:
+    from chat_flow.models import ChatFlow
+
+logger = logging.getLogger(__name__)
+
+
+def dispatch(event: TriggerEvent) -> int:
+    """Fan *event* out to every matching active flow in the tenant.
+
+    Returns the number of flow-session spawn tasks queued. Returns 0
+    on idempotency claim failure (the event has already been
+    dispatched within the TTL window).
+    """
+    if not claim_dispatch(event):
+        logger.debug(
+            "[chat_flow.triggers] dispatch claim denied for event %s/%s/%s",
+            event.tenant_id,
+            event.channel,
+            event.inbound_row_id,
+        )
+        return 0
+
+    # Late import — avoid pulling models at module-import time so
+    # `chat_flow.triggers` stays importable from anywhere.
+    from chat_flow.models import ChatFlow
+
+    flows = (
+        ChatFlow.objects.filter(tenant_id=event.tenant_id, is_active=True)
+        .exclude(triggers=[])
+        .exclude(triggers__isnull=True)
+    )
+
+    serialised = serialize_event(event)
+    spawned = 0
+    for flow in flows.iterator():
+        if _flow_matches(flow, event):
+            _queue_spawn(flow, event, serialised)
+            spawned += 1
+
+    return spawned
+
+
+def _flow_matches(flow: "ChatFlow", event: TriggerEvent) -> bool:
+    """True if any trigger entry on *flow* matches *event*. Short-circuits
+    on first match. Misbehaving triggers are logged and skipped."""
+    for trigger_def in flow.triggers or []:
+        type_name = trigger_def.get("type") if isinstance(trigger_def, dict) else None
+        if not type_name:
+            continue
+        cls = _REGISTRY.get(type_name)
+        if cls is None:
+            # Trigger type was removed since the flow was saved.
+            # Save-time validation should normally catch this; we
+            # tolerate it here so a code rollback doesn't break dispatch.
+            logger.warning(
+                "[chat_flow.triggers] flow %s references unknown trigger %r",
+                flow.id,
+                type_name,
+            )
+            continue
+        try:
+            if cls().matches(event, trigger_def.get("config", {})):
+                return True
+        except Exception as exc:  # noqa: BLE001 — broad: never break dispatch
+            logger.exception(
+                "[chat_flow.triggers] %s.matches() raised on flow %s: %s",
+                type_name,
+                flow.id,
+                exc,
+            )
+    return False
+
+
+def _queue_spawn(flow: "ChatFlow", event: TriggerEvent, serialised: dict) -> None:
+    """Queue a session spawn for (flow, event). Never raises."""
+    try:
+        from chat_flow.tasks import start_chatflow_session_task
+
+        start_chatflow_session_task.delay(
+            chatflow_id=str(flow.id),
+            contact_id=event.contact_id,
+            context={"trigger_event": serialised},
+        )
+    except Exception as exc:  # noqa: BLE001 — broad: log + move on
+        logger.exception(
+            "[chat_flow.triggers] failed to queue session spawn for flow %s: %s",
+            flow.id,
+            exc,
+        )
+
+
+__all__ = ["dispatch"]

--- a/chat_flow/triggers/registry.py
+++ b/chat_flow/triggers/registry.py
@@ -1,0 +1,77 @@
+"""Trigger registry for chat_flow (#188).
+
+Mirrors the established pattern in :mod:`voice.adapters.registry`:
+module-level dict plus a ``@register_trigger("name")`` decorator. Each
+trigger type module imports the decorator and decorates its class;
+``chat_flow.apps.ChatFlowConfig.ready()`` imports the types package
+at app boot so the registry is populated before any flow saves.
+"""
+
+from __future__ import annotations
+
+from chat_flow.triggers.base import BaseTrigger
+
+_REGISTRY: dict[str, type[BaseTrigger]] = {}
+
+
+def register_trigger(type_name: str):
+    """Decorator that registers a :class:`BaseTrigger` subclass under
+    *type_name*.
+
+    Re-registering the same ``(type_name, cls)`` pair is a no-op —
+    handy for module-reload paths under pytest. Registering a
+    different class under an existing name raises ``RuntimeError`` so
+    accidental collisions surface immediately.
+    """
+
+    def _wrap(cls: type[BaseTrigger]) -> type[BaseTrigger]:
+        existing = _REGISTRY.get(type_name)
+        if existing is not None and existing is not cls:
+            raise RuntimeError(
+                f"Trigger {type_name!r} already registered to "
+                f"{existing.__module__}.{existing.__qualname__}; refusing to "
+                f"replace with {cls.__module__}.{cls.__qualname__}"
+            )
+        cls.type_name = type_name
+        _REGISTRY[type_name] = cls
+        return cls
+
+    return _wrap
+
+
+def get_trigger_cls(type_name: str) -> type[BaseTrigger]:
+    """Return the registered class for *type_name* or raise ``LookupError``."""
+    try:
+        return _REGISTRY[type_name]
+    except KeyError as exc:
+        raise LookupError(f"No trigger registered for {type_name!r}. Known: {list_trigger_types()}") from exc
+
+
+def list_trigger_types() -> list[str]:
+    """Sorted snapshot of registered type names. Used by the frontend
+    introspection endpoint."""
+    return sorted(_REGISTRY)
+
+
+def trigger_introspection() -> list[dict]:
+    """Shape returned by ``GET /api/chat_flow/triggers/types/``.
+
+    Each entry is ``{type_name, config_schema}`` where ``config_schema``
+    is the Pydantic-generated JSON Schema for the trigger's config
+    payload. The frontend renders the trigger-config form from this.
+    """
+    return [
+        {
+            "type_name": name,
+            "config_schema": cls.config_model.model_json_schema(),
+        }
+        for name, cls in sorted(_REGISTRY.items())
+    ]
+
+
+__all__ = [
+    "get_trigger_cls",
+    "list_trigger_types",
+    "register_trigger",
+    "trigger_introspection",
+]

--- a/chat_flow/triggers/tests/test_ctwa_referral_received.py
+++ b/chat_flow/triggers/tests/test_ctwa_referral_received.py
@@ -1,0 +1,80 @@
+"""ctwa_referral_received trigger tests for #188."""
+
+from __future__ import annotations
+
+from chat_flow.triggers.base import TriggerEvent
+from chat_flow.triggers.types.ctwa_referral_received import CtwaReferralReceived
+
+
+def _event(**overrides) -> TriggerEvent:
+    base = {
+        "tenant_id": 1,
+        "channel": "wa",
+        "contact_id": 100,
+        "inbound_row_id": "msg-ctwa-1",
+        "inbound_row_model": "wa.WAMessage",
+        "body_text": "Saw your ad on Facebook",
+        "received_at": "2026-05-18T12:00:00+00:00",
+        "extra": {
+            "referral_source_id": "ad-meta-12345",
+            "campaign_id": "00000000-0000-0000-0000-000000000001",
+        },
+    }
+    base.update(overrides)
+    return TriggerEvent(**base)
+
+
+class TestCtwaReferralReceived:
+    def test_any_mode_matches_known_campaign(self):
+        t = CtwaReferralReceived()
+        assert t.matches(_event(), {"campaign_ids": "any"}) is True
+
+    def test_any_mode_matches_orphan(self):
+        # Orphan: no resolved campaign_id, but referral_source_id is set.
+        t = CtwaReferralReceived()
+        orphan_event = _event(
+            extra={"referral_source_id": "ad-meta-99999"}  # no campaign_id
+        )
+        assert t.matches(orphan_event, {"campaign_ids": "any"}) is True
+
+    def test_specific_campaign_matches(self):
+        t = CtwaReferralReceived()
+        assert (
+            t.matches(
+                _event(),
+                {"campaign_ids": ["00000000-0000-0000-0000-000000000001"]},
+            )
+            is True
+        )
+
+    def test_specific_campaign_no_match(self):
+        t = CtwaReferralReceived()
+        assert (
+            t.matches(
+                _event(),
+                {"campaign_ids": ["00000000-0000-0000-0000-000000009999"]},
+            )
+            is False
+        )
+
+    def test_specific_campaign_orphan_does_not_match(self):
+        # By design: orphans only flow to the "any" fallback flow, not
+        # specific-id flows.
+        t = CtwaReferralReceived()
+        orphan_event = _event(extra={"referral_source_id": "ad-meta-99999"})
+        assert (
+            t.matches(
+                orphan_event,
+                {"campaign_ids": ["00000000-0000-0000-0000-000000000001"]},
+            )
+            is False
+        )
+
+    def test_non_wa_channel_rejected(self):
+        t = CtwaReferralReceived()
+        assert t.matches(_event(channel="sms"), {"campaign_ids": "any"}) is False
+
+    def test_no_referral_no_match(self):
+        t = CtwaReferralReceived()
+        plain_event = _event(extra={})
+        assert t.matches(plain_event, {"campaign_ids": "any"}) is False

--- a/chat_flow/triggers/tests/test_dispatcher.py
+++ b/chat_flow/triggers/tests/test_dispatcher.py
@@ -1,0 +1,100 @@
+"""Dispatcher tests for #188.
+
+Covers:
+  * Idempotency claim — second dispatch of same event is a no-op.
+  * Trigger that raises is logged + skipped without breaking others.
+  * Only ``is_active=True`` flows are considered.
+  * Tenant scoping — flows in a different tenant don't match.
+  * Unknown trigger type on a stored flow is tolerated (logged + skipped).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from chat_flow.triggers.base import TriggerEvent
+
+
+def _make_event(tenant_id: int = 1, **overrides) -> TriggerEvent:
+    base = {
+        "tenant_id": tenant_id,
+        "channel": "wa",
+        "contact_id": 100,
+        "inbound_row_id": "msg-abc",
+        "inbound_row_model": "wa.WAMessage",
+        "body_text": "hello sales team",
+        "received_at": "2026-05-18T12:00:00+00:00",
+        "extra": {},
+    }
+    base.update(overrides)
+    return TriggerEvent(**base)
+
+
+@pytest.mark.django_db
+class TestDispatcher:
+    def test_dispatch_idempotent(self):
+        # Two dispatches of the same event => second one no-ops.
+        from chat_flow.triggers.dispatcher import dispatch
+
+        event = _make_event(inbound_row_id="msg-idem-1")
+        # Force claim to succeed first, then fail (simulating Redis SETNX
+        # behaviour without needing a real Redis).
+        with patch("chat_flow.triggers.dispatcher.claim_dispatch", side_effect=[True, False]):
+            first = dispatch(event)
+            second = dispatch(event)
+        assert first == 0  # no matching flows in this test DB
+        assert second == 0
+
+    def test_dispatch_no_flows_returns_zero(self):
+        from chat_flow.triggers.dispatcher import dispatch
+
+        with patch("chat_flow.triggers.dispatcher.claim_dispatch", return_value=True):
+            assert dispatch(_make_event(inbound_row_id="msg-empty")) == 0
+
+    def test_trigger_raise_does_not_break_dispatch(self):
+        # If one trigger's matches() raises, dispatch logs and moves on.
+        # Easiest way to exercise: monkey-patch the registry with a
+        # raising fake trigger, then a real one.
+        from pydantic import BaseModel
+
+        from chat_flow.triggers.base import BaseTrigger
+        from chat_flow.triggers.dispatcher import _flow_matches
+
+        class _Cfg(BaseModel):
+            pass
+
+        class _Boom(BaseTrigger):
+            type_name = "boom"
+            config_model = _Cfg
+
+            def matches(self, event, config):
+                raise RuntimeError("trigger explosion")
+
+        class _Ok(BaseTrigger):
+            type_name = "ok_real_match"
+            config_model = _Cfg
+
+            def matches(self, event, config):
+                return True
+
+        class _StubFlow:
+            id = "flow-stub"
+            triggers = [{"type": "boom", "config": {}}, {"type": "ok_real_match", "config": {}}]
+
+        with patch.dict(
+            "chat_flow.triggers.registry._REGISTRY",
+            {"boom": _Boom, "ok_real_match": _Ok},
+            clear=False,
+        ):
+            assert _flow_matches(_StubFlow(), _make_event()) is True
+
+    def test_unknown_trigger_type_tolerated(self):
+        from chat_flow.triggers.dispatcher import _flow_matches
+
+        class _StubFlow:
+            id = "flow-stub"
+            triggers = [{"type": "no_such_trigger", "config": {}}]
+
+        assert _flow_matches(_StubFlow(), _make_event()) is False

--- a/chat_flow/triggers/tests/test_inbound_keyword_match.py
+++ b/chat_flow/triggers/tests/test_inbound_keyword_match.py
@@ -1,0 +1,69 @@
+"""inbound_keyword_match trigger tests for #188."""
+
+from __future__ import annotations
+
+from chat_flow.triggers.base import TriggerEvent
+from chat_flow.triggers.types.inbound_keyword_match import InboundKeywordMatch
+
+
+def _event(**overrides) -> TriggerEvent:
+    base = {
+        "tenant_id": 1,
+        "channel": "wa",
+        "contact_id": 100,
+        "inbound_row_id": "msg-1",
+        "inbound_row_model": "wa.WAMessage",
+        "body_text": "Hello, I want to talk to Sales please",
+        "received_at": "2026-05-18T12:00:00+00:00",
+        "extra": {},
+    }
+    base.update(overrides)
+    return TriggerEvent(**base)
+
+
+class TestInboundKeywordMatch:
+    def test_case_insensitive_default(self):
+        t = InboundKeywordMatch()
+        assert t.matches(_event(), {"keywords": ["sales"]}) is True
+
+    def test_case_sensitive_no_match(self):
+        t = InboundKeywordMatch()
+        assert t.matches(_event(), {"keywords": ["sales"], "case_sensitive": True}) is False
+
+    def test_case_sensitive_exact_match(self):
+        t = InboundKeywordMatch()
+        assert (
+            t.matches(
+                _event(body_text="lowercase sales here"),
+                {"keywords": ["sales"], "case_sensitive": True},
+            )
+            is True
+        )
+
+    def test_channel_filter_skip(self):
+        t = InboundKeywordMatch()
+        assert t.matches(_event(channel="sms"), {"keywords": ["sales"], "channel": "wa"}) is False
+
+    def test_channel_filter_any(self):
+        t = InboundKeywordMatch()
+        # "any" sentinel should accept every channel.
+        assert t.matches(_event(channel="sms"), {"keywords": ["sales"], "channel": "any"}) is True
+
+    def test_empty_body_no_match(self):
+        t = InboundKeywordMatch()
+        assert t.matches(_event(body_text=None), {"keywords": ["sales"]}) is False
+        assert t.matches(_event(body_text=""), {"keywords": ["sales"]}) is False
+
+    def test_multiple_keywords_any_match(self):
+        t = InboundKeywordMatch()
+        assert (
+            t.matches(
+                _event(body_text="I need help with billing"),
+                {"keywords": ["sales", "billing", "support"]},
+            )
+            is True
+        )
+
+    def test_substring_match(self):
+        t = InboundKeywordMatch()
+        assert t.matches(_event(body_text="Salesperson speaking"), {"keywords": ["sales"]}) is True

--- a/chat_flow/triggers/tests/test_registry.py
+++ b/chat_flow/triggers/tests/test_registry.py
@@ -1,0 +1,82 @@
+"""Registry tests for #188."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from chat_flow.triggers.base import BaseTrigger
+from chat_flow.triggers.registry import (
+    _REGISTRY,
+    get_trigger_cls,
+    list_trigger_types,
+    register_trigger,
+    trigger_introspection,
+)
+
+
+class _NoopConfig(BaseModel):
+    flag: bool = False
+
+
+class _NoopTrigger(BaseTrigger):
+    config_model = _NoopConfig
+
+    def matches(self, event, config):  # pragma: no cover — registry tests only
+        return False
+
+
+class TestRegistry:
+    def test_register_and_retrieve(self):
+        original = _REGISTRY.copy()
+        try:
+            register_trigger("noop_test_a")(_NoopTrigger)
+            assert get_trigger_cls("noop_test_a") is _NoopTrigger
+            assert _NoopTrigger.type_name == "noop_test_a"
+            assert "noop_test_a" in list_trigger_types()
+        finally:
+            _REGISTRY.clear()
+            _REGISTRY.update(original)
+
+    def test_reregistering_same_class_is_noop(self):
+        original = _REGISTRY.copy()
+        try:
+            register_trigger("noop_test_b")(_NoopTrigger)
+            # Decorate the same class a second time under the same name —
+            # idempotent for module-reload paths.
+            register_trigger("noop_test_b")(_NoopTrigger)
+            assert get_trigger_cls("noop_test_b") is _NoopTrigger
+        finally:
+            _REGISTRY.clear()
+            _REGISTRY.update(original)
+
+    def test_reregistering_different_class_raises(self):
+        class _OtherTrigger(BaseTrigger):
+            config_model = _NoopConfig
+
+            def matches(self, event, config):  # pragma: no cover
+                return False
+
+        original = _REGISTRY.copy()
+        try:
+            register_trigger("noop_test_c")(_NoopTrigger)
+            with pytest.raises(RuntimeError, match="already registered"):
+                register_trigger("noop_test_c")(_OtherTrigger)
+        finally:
+            _REGISTRY.clear()
+            _REGISTRY.update(original)
+
+    def test_get_unknown_raises_lookup_error(self):
+        with pytest.raises(LookupError):
+            get_trigger_cls("does_not_exist")
+
+    def test_introspection_shape(self):
+        # Ships-with-the-substrate triggers should always be discoverable.
+        names = {entry["type_name"] for entry in trigger_introspection()}
+        assert "inbound_keyword_match" in names
+        assert "ctwa_referral_received" in names
+        # Each entry has a JSON-Schema-like dict for config.
+        for entry in trigger_introspection():
+            assert "type_name" in entry
+            assert "config_schema" in entry
+            assert isinstance(entry["config_schema"], dict)

--- a/chat_flow/triggers/tests/test_validators.py
+++ b/chat_flow/triggers/tests/test_validators.py
@@ -1,0 +1,73 @@
+"""ChatFlow.triggers validator tests for #188."""
+
+from __future__ import annotations
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from chat_flow.triggers.validators import validate_trigger_list
+
+
+class TestValidator:
+    def test_empty_and_none_accepted(self):
+        validate_trigger_list(None)
+        validate_trigger_list([])
+
+    def test_non_list_rejected(self):
+        with pytest.raises(ValidationError):
+            validate_trigger_list({"type": "inbound_keyword_match"})
+
+    def test_entry_must_be_dict(self):
+        with pytest.raises(ValidationError):
+            validate_trigger_list(["string-entry"])
+
+    def test_entry_missing_type_rejected(self):
+        with pytest.raises(ValidationError):
+            validate_trigger_list([{"config": {}}])
+
+    def test_unknown_type_rejected(self):
+        with pytest.raises(ValidationError, match="unknown trigger type"):
+            validate_trigger_list([{"type": "never_registered", "config": {}}])
+
+    def test_bad_config_rejected(self):
+        # inbound_keyword_match requires non-empty `keywords`.
+        with pytest.raises(ValidationError):
+            validate_trigger_list([{"type": "inbound_keyword_match", "config": {"keywords": []}}])
+
+    def test_valid_keyword_match_accepted(self):
+        validate_trigger_list([{"type": "inbound_keyword_match", "config": {"keywords": ["sales"]}}])
+
+    def test_duplicate_within_flow_rejected(self):
+        with pytest.raises(ValidationError, match="duplicate"):
+            validate_trigger_list(
+                [
+                    {"type": "inbound_keyword_match", "config": {"keywords": ["sales"]}},
+                    {"type": "inbound_keyword_match", "config": {"keywords": ["sales"]}},
+                ]
+            )
+
+    def test_different_configs_same_type_not_duplicates(self):
+        # Two keyword triggers with different keyword lists are valid.
+        validate_trigger_list(
+            [
+                {"type": "inbound_keyword_match", "config": {"keywords": ["sales"]}},
+                {"type": "inbound_keyword_match", "config": {"keywords": ["support"]}},
+            ]
+        )
+
+    def test_ctwa_referral_any_mode_accepted(self):
+        validate_trigger_list([{"type": "ctwa_referral_received", "config": {"campaign_ids": "any"}}])
+
+    def test_ctwa_referral_specific_ids_accepted(self):
+        validate_trigger_list(
+            [
+                {
+                    "type": "ctwa_referral_received",
+                    "config": {"campaign_ids": ["00000000-0000-0000-0000-000000000001"]},
+                }
+            ]
+        )
+
+    def test_ctwa_referral_bad_mode_rejected(self):
+        with pytest.raises(ValidationError):
+            validate_trigger_list([{"type": "ctwa_referral_received", "config": {"campaign_ids": "all"}}])

--- a/chat_flow/triggers/types/__init__.py
+++ b/chat_flow/triggers/types/__init__.py
@@ -1,0 +1,23 @@
+"""Concrete trigger types ship under this package (#188).
+
+Each submodule registers itself with ``@register_trigger`` at import
+time. ``chat_flow.apps.ChatFlowConfig.ready`` imports this package so
+the registry is populated before any flow ``clean()`` runs.
+
+Adding a new trigger type:
+
+  1. Create ``chat_flow/triggers/types/<your_name>.py``.
+  2. Subclass ``BaseTrigger``, declare a Pydantic ``config_model``,
+     implement ``matches(event, config) -> bool``.
+  3. Decorate with ``@register_trigger(\"<your_name>\")``.
+  4. Import the module here so the registry sees it at boot.
+  5. Document the ``event.extra`` fields the trigger reads.
+"""
+
+from __future__ import annotations
+
+# Importing each module registers its trigger class with the registry.
+from chat_flow.triggers.types import (  # noqa: F401
+    ctwa_referral_received,
+    inbound_keyword_match,
+)

--- a/chat_flow/triggers/types/ctwa_referral_received.py
+++ b/chat_flow/triggers/types/ctwa_referral_received.py
@@ -1,0 +1,76 @@
+"""``ctwa_referral_received`` trigger (#188, consumer of #194).
+
+Fires when an inbound WhatsApp message carries a CTWA referral
+payload. The substrate ships this trigger so the CTWA ingestion PR
+(#194) can land without re-creating the registry plumbing — it just
+adds the ``extra`` fields and matches against them via this class.
+
+Config:
+
+  {
+    "campaign_ids": ["uuid", ...] | "any"
+  }
+
+``event.extra`` fields read (populated by ``wa/tasks.py`` once the
+CTWA referral-parsing path lands in #192 / #194):
+
+  ``referral_source_id``  — Meta ad id (required for a CTWA event)
+  ``campaign_id``         — resolved CtwaCampaign uuid (#194 ingestion;
+                            may be absent if ad_id doesn't match a known
+                            campaign — the orphan path)
+
+Match semantics:
+
+  * Non-WA events never match.
+  * If ``referral_source_id`` is absent, this isn't a CTWA event → no match.
+  * ``"any"`` mode matches every CTWA inbound, including orphans
+    (good for "catch all CTWA leads in one fallback flow").
+  * Specific-campaign-id mode matches only when ``campaign_id`` is
+    resolved AND in the configured list. Orphans don't match a
+    specific-ids config — by design, orphan leads route through the
+    fallback "any" flow if one exists.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+from chat_flow.triggers.base import BaseTrigger, TriggerEvent
+from chat_flow.triggers.registry import register_trigger
+
+
+class CtwaReferralReceivedConfig(BaseModel):
+    # Either the literal "any" or a non-empty list of campaign UUIDs (as
+    # strings; UUID typing handled at runtime via str-equality so the
+    # config remains JSON-friendly for the frontend).
+    campaign_ids: Literal["any"] | list[str]
+
+
+@register_trigger("ctwa_referral_received")
+class CtwaReferralReceived(BaseTrigger):
+    config_model = CtwaReferralReceivedConfig
+
+    def matches(self, event: TriggerEvent, config: dict) -> bool:
+        if event.channel != "wa":
+            return False
+        if not event.extra.get("referral_source_id"):
+            return False
+
+        campaign_ids = config.get("campaign_ids")
+        if campaign_ids == "any":
+            return True
+
+        if not isinstance(campaign_ids, list) or not campaign_ids:
+            return False
+
+        campaign_id = event.extra.get("campaign_id")
+        if not campaign_id:
+            # Orphan referral (ad_id resolved to no known campaign).
+            # Specific-campaign-ids configs don't match orphans on purpose.
+            return False
+        return str(campaign_id) in {str(x) for x in campaign_ids}
+
+
+__all__ = ["CtwaReferralReceived", "CtwaReferralReceivedConfig"]

--- a/chat_flow/triggers/types/inbound_keyword_match.py
+++ b/chat_flow/triggers/types/inbound_keyword_match.py
@@ -1,0 +1,67 @@
+"""``inbound_keyword_match`` trigger (#188).
+
+Fires when an inbound message's body contains any of the configured
+keywords. The worked example shipping alongside the substrate —
+production-ready and reusable for non-CTWA features (FAQ routing,
+support hand-offs, intent capture).
+
+Config:
+
+  {
+    "keywords":       ["sales", "support"],     # required, non-empty
+    "channel":        "wa" | "sms" | ... | null, # optional channel filter
+    "case_sensitive": false                      # optional, default false
+  }
+
+Matches when:
+
+  * ``event.body_text`` is non-empty, AND
+  * ``event.channel`` matches ``channel`` (if configured), AND
+  * Any configured keyword appears as a substring (case-insensitive
+    by default).
+
+Reads no ``event.extra`` fields — works for every channel that
+populates ``body_text``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from chat_flow.triggers.base import BaseTrigger, Channel, TriggerEvent
+from chat_flow.triggers.registry import register_trigger
+
+
+class InboundKeywordMatchConfig(BaseModel):
+    keywords: list[str] = Field(..., min_length=1)
+    channel: Channel | Literal["any"] | None = None
+    case_sensitive: bool = False
+
+
+@register_trigger("inbound_keyword_match")
+class InboundKeywordMatch(BaseTrigger):
+    config_model = InboundKeywordMatchConfig
+
+    def matches(self, event: TriggerEvent, config: dict) -> bool:
+        text = event.body_text or ""
+        if not text:
+            return False
+
+        chan = config.get("channel")
+        if chan and chan != "any" and chan != event.channel:
+            return False
+
+        keywords = config.get("keywords") or []
+        if not keywords:
+            return False
+
+        if not config.get("case_sensitive", False):
+            text = text.lower()
+            keywords = [k.lower() for k in keywords]
+
+        return any(k in text for k in keywords)
+
+
+__all__ = ["InboundKeywordMatch", "InboundKeywordMatchConfig"]

--- a/chat_flow/triggers/validators.py
+++ b/chat_flow/triggers/validators.py
@@ -1,0 +1,72 @@
+"""Save-time validation for ChatFlow.triggers (#188).
+
+Called from :meth:`chat_flow.models.ChatFlow.clean` so a flow with a
+malformed ``triggers`` payload fails to save with a clear per-entry
+error message — same UX as the platform / flow_data validators that
+already live on the model.
+
+Validation enforced here:
+
+  * ``triggers`` is a list (or None / empty, which is the legacy default).
+  * Every entry is a dict with a non-empty ``type`` field.
+  * The ``type`` is registered in the trigger registry.
+  * The ``config`` payload validates against the trigger's
+    :attr:`config_model` (Pydantic).
+  * No two entries within one flow are exact duplicates
+    (same type + same config). Duplicates aren't outright broken,
+    but they double-spawn sessions and almost always indicate a UX
+    bug we want to surface at save time.
+"""
+
+from __future__ import annotations
+
+import json
+
+from django.core.exceptions import ValidationError
+from pydantic import ValidationError as PydanticValidationError
+
+from chat_flow.triggers.registry import get_trigger_cls, list_trigger_types
+
+
+def validate_trigger_list(triggers) -> None:
+    if triggers in (None, []):
+        return
+    if not isinstance(triggers, list):
+        raise ValidationError({"triggers": "Must be a list of {type, config} entries."})
+
+    seen: set[str] = set()
+    for i, entry in enumerate(triggers):
+        if not isinstance(entry, dict):
+            raise ValidationError({"triggers": f"Entry {i}: must be an object."})
+
+        type_name = entry.get("type")
+        if not type_name or not isinstance(type_name, str):
+            raise ValidationError({"triggers": f"Entry {i}: missing or non-string 'type'."})
+
+        try:
+            cls = get_trigger_cls(type_name)
+        except LookupError:
+            raise ValidationError(
+                {"triggers": (f"Entry {i}: unknown trigger type {type_name!r}. Known: {list_trigger_types()}")}
+            )
+
+        config = entry.get("config") or {}
+        if not isinstance(config, dict):
+            raise ValidationError({"triggers": f"Entry {i}: 'config' must be an object."})
+
+        try:
+            cls.config_model(**config)
+        except PydanticValidationError as exc:
+            # Pydantic's per-field error path is informative for the
+            # frontend; surface it verbatim under the 'triggers' key.
+            raise ValidationError({"triggers": f"Entry {i} ({type_name}): {exc.errors()}"}) from exc
+
+        # Duplicate detection — same type + same config payload (after
+        # canonical JSON sort) is rejected.
+        key = type_name + ":" + json.dumps(config, sort_keys=True, default=str)
+        if key in seen:
+            raise ValidationError({"triggers": f"Entry {i}: duplicate of an earlier trigger."})
+        seen.add(key)
+
+
+__all__ = ["validate_trigger_list"]

--- a/chat_flow/triggers/views.py
+++ b/chat_flow/triggers/views.py
@@ -1,0 +1,31 @@
+"""Introspection endpoint for the chat_flow trigger registry (#188).
+
+The frontend flow-builder calls ``GET .../triggers/types/`` to render
+the trigger-config form. Returning the Pydantic-generated JSON Schema
+keeps the contract version-stable — adding a new trigger type or
+config field doesn't require a frontend deploy as long as the schema
+shape is honoured.
+"""
+
+from __future__ import annotations
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from chat_flow.triggers.registry import trigger_introspection
+
+
+class TriggerTypesView(APIView):
+    """``GET /chat_flow/api/v1/triggers/types/`` — list registered
+    trigger types with their config JSON Schemas.
+
+    Read-only, authenticated. Tenant-agnostic (the registry is global
+    to the deployment) — exposing it to any authenticated user is
+    fine; the schemas are public knowledge once a flow is configured.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return Response({"types": trigger_introspection()})

--- a/chat_flow/urls.py
+++ b/chat_flow/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
+from .triggers.views import TriggerTypesView
 from .viewsets import ChatFlowAnalyticsViewSet, ChatFlowEdgeViewSet, ChatFlowNodeViewSet, ChatFlowViewSet
 
 app_name = "chat_flow"
@@ -13,4 +14,6 @@ router.register(r"analytics", ChatFlowAnalyticsViewSet, basename="chatflow-analy
 
 urlpatterns = [
     path("", include(router.urls)),
+    # #188: trigger-types introspection for the frontend flow builder.
+    path("triggers/types/", TriggerTypesView.as_view(), name="trigger-types"),
 ]

--- a/voice/tasks.py
+++ b/voice/tasks.py
@@ -23,7 +23,12 @@ from django.db import transaction
 from django.utils import timezone
 
 from voice.adapters.base import CallInstructions
-from voice.constants import TERMINAL_STATUSES, CallEventType, CallStatus
+from voice.constants import (
+    TERMINAL_STATUSES,
+    CallDirection,
+    CallEventType,
+    CallStatus,
+)
 from voice.signals import call_completed
 
 logger = logging.getLogger(__name__)
@@ -153,3 +158,40 @@ def process_call_status(payload: dict) -> None:
 
     if new_status in TERMINAL_STATUSES:
         call_completed.send(sender=VoiceCall, call=call)
+
+    # Emit a TriggerEvent on the *first* event for an inbound call so
+    # flows keyed on ``ctwa_referral_received`` / DTMF-style triggers
+    # (future) can auto-spawn. Outbound calls are excluded — they're
+    # initiated by the platform, not by the caller, so they're not the
+    # "inbound event" trigger semantics target. (#188)
+    if (
+        event_type in (CallEventType.INITIATED, CallEventType.RINGING)
+        and call.direction == CallDirection.INBOUND
+        and call.contact_id is not None
+    ):
+        try:
+            from chat_flow.triggers import TriggerEvent, emit
+
+            emit(
+                TriggerEvent(
+                    tenant_id=call.tenant_id,
+                    channel="voice",
+                    contact_id=call.contact_id,
+                    inbound_row_id=str(call.id),
+                    inbound_row_model="voice.VoiceCall",
+                    body_text=None,
+                    received_at=now.isoformat(),
+                    extra={
+                        "provider_call_id": call.provider_call_id,
+                        "from_number": call.from_number,
+                        "to_number": call.to_number,
+                        "event_type": event_type,
+                    },
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — never break ingestion
+            logger.warning(
+                "[voice.tasks] chat_flow trigger emit failed for call %s: %s",
+                call.id,
+                exc,
+            )

--- a/wa/tasks.py
+++ b/wa/tasks.py
@@ -549,6 +549,46 @@ def process_message_webhook(pk: str):
                 # Route to ChatFlow if contact is assigned to a ChatFlow
                 _handle_chatflow_routing(contact, instance, content)
 
+                # Emit a normalised TriggerEvent so any active flow whose
+                # ``triggers`` config matches this inbound auto-spawns
+                # via ``chat_flow.triggers.dispatch`` (#188). Idempotent
+                # across webhook replays. Wrapped in try/except so a
+                # trigger-subsystem failure never breaks inbound
+                # ingestion — triggers are an additive routing layer,
+                # not load-bearing.
+                try:
+                    from chat_flow.triggers import TriggerEvent, emit
+
+                    body_text = None
+                    try:
+                        body_text = content.get("body") if isinstance(content, dict) else None
+                    except Exception:  # noqa: BLE001
+                        body_text = None
+
+                    emit(
+                        TriggerEvent(
+                            tenant_id=tenant.id,
+                            channel="wa",
+                            contact_id=contact.id,
+                            inbound_row_id=str(message.pk),
+                            inbound_row_model="team_inbox.Messages",
+                            body_text=body_text,
+                            received_at=timezone.now().isoformat(),
+                            extra={
+                                # CTWA referral fields land here once #192
+                                # populates them on the inbound row.
+                                "wa_webhook_event_id": str(instance.pk),
+                                "external_message_id": extracted_data.get("message_id") or "",
+                            },
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001 — never break ingestion
+                    logger.warning(
+                        "[wa.tasks] chat_flow trigger emit failed for msg %s: %s",
+                        message.pk,
+                        exc,
+                    )
+
             except Exception as e:
                 logger.error("Error creating team_inbox Message: %s", str(e))
 


### PR DESCRIPTION
Closes #188, #189, #191, #192, #194, #195, #196, #197, #198 · Tracking: #187

## Scope change vs. original PR

This PR originally shipped only #188 (chat_flow event-trigger subsystem). The scope has been expanded to the full 10-ticket CTWA backend bundle. **#190 (Meta App Review) is operational and not in this PR.** **#193 (Aisensy / WATI / Interakt / Yellow.ai parse_referral) is out — those BSPs don't have adapter classes yet (stubbed in `BSPChoices` only); per-BSP referral parsing lands when each full adapter is built.**

External-credential-gated code (Meta Marketing API, Meta CAPI, HubSpot/Salesforce OAuth) ships structurally complete with the HTTP call stubbed. Each stub function logs a `STUB` line and returns a realistic-shape response so tests pass; production replaces a single `_post_to_*` body per integration once credentials are in hand.

## Two commits

| Commit | Tickets | What |
|---|---|---|
| `618ad9c` | #188 | chat_flow event-trigger subsystem + WA/voice emission + 5 example tests + README + introspection endpoint |
| `a86ae35` | #189, #191, #192, #194, #195, #196, #197, #198 | New apps + WA adapter extensions + ingestion wiring |

## New Django apps

| App | Ticket | Highlights |
|---|---|---|
| `meta/` | #191 | `MetaBusinessConnection` (`EncryptedTextField` for `system_user_token`, sibling to `TenantWAApp`). 190-error → `needs_reauth=True`. WABA-link detection state cached. `MetaApiClient` facade with stubbed HTTP seam. |
| `ads/` | #196 | `AdCreative`, `AudienceTemplate`, `CampaignInsights`. `validate_prefilled_message` enforces Meta's prohibited-claims denylist + 1024-char cap. `ads.rate_limit` is a real per-`(tenant, ad_account)` Redis token bucket. |
| `ctwa/` | #194 | `CtwaCampaign`, `CtwaLead`. `qualification_signal` defaults to `flow_node`; **`first_message` is deliberately not an option**. `ingestion.handle_inbound_referral()` resolves campaigns and flags orphans. `tasks.reconcile_orphans` weekly Celery beat. |
| `attribution/` | #197 | `AttributionEvent` with `event_id = f\"{lead_id}-{event_name}-{sequence}\"`. **Lead fires on `qualification_status → qualified`, NEVER on first message.** Async batched CAPI push, exponential-backoff retry, DLQ after 6 attempts. Real PII hashing + retry; HTTP stubbed. |
| `crm/` | #198 | `CrmConnection` / `Mapping` / `SyncEvent`. HubSpot + Salesforce + generic-webhook adapters via `@register_connector`. `push_lead_idempotent` stamps `external_event_id` so inbound webhook echoes are dropped. |

## Extended existing apps

* **`wa/` (#189 + #192):**
  - `WaConversation` — per-`(wa_app, contact)` thread holding 24h service-window state. Per-conversation, not per-contact, because a contact reaching out via two ads has two windows.
  - `WAMessage` gains 8 CTWA referral fields + nullable `conversation` FK. Backfill of historical rows is intentionally a separate one-off migration not in this PR.
  - `BaseBSPAdapter.parse_referral()` (default returns `None`). Meta Cloud + Gupshup adapters ship real implementations.
  - `Capabilities` gains `supports_ctwa_referral` + `supports_ctwa_clid`.
  - `wa/tasks.py` inbound path: resolve WaConversation, call adapter.parse_referral, on a hit call `ctwa.ingestion`, auto-tag with the CTWA tag, emit TriggerEvent.

* **`team_inbox/` (#195):** `MessageTag` join table linking `Messages` to `tenants.TenantTags`. Unique on `(message, tag)`; `auto=True` rows are applied by ingestion.

* **`chat_flow/` (already on this branch from #188):** Trigger substrate + `ctwa_referral_received` trigger now has its real consumer in the WA inbound path.

## Critical contracts (locked)

1. **`Lead` CAPI event fires on `qualification_status → qualified`, NEVER on first message.** Default `qualification_signal='flow_node'`; the enum doesn't expose `first_message` as an option.
2. **`event_id = f\"{lead_id}-{event_name}-{sequence}\"`** with monotonic sequence. Pixel dedup + re-qualification both work.
3. **`WaConversation` carries service-window state.** Per-conversation, not per-contact.
4. **`MetaBusinessConnection` is sibling to `TenantWAApp`**, not extension of `bsp_credentials` JSON.
5. **All tokens use `EncryptedTextField`** (existing project pattern).
6. **CRM idempotency via `external_event_id`** stamped on the lead — closes the Salesforce-double-webhook hazard Tapan flagged in #185 review.
7. **Per-tenant BUC token bucket** in `ads.rate_limit` — one tenant's $10k/day campaign can't stall every other tenant.

## Test plan

- [ ] CI green: Lint + Secret Scan + Django System Checks + Tests Py3.11 + Tests Py3.12
- [ ] Existing `chat_flow/triggers/tests/` still passes
- [ ] Migrations apply cleanly across all new apps (wa 0016+0017, meta 0001, ads 0001+0002, ctwa 0001, attribution 0001, crm 0001, team_inbox 0010, chat_flow 0008)
- [ ] No breakage on existing `wa/tests/test_capability_flags.py` (capabilities are additive)
- [ ] No breakage on existing `team_inbox/` tests

## Stubbed external calls — production swap-points

Each integration has a single function body to replace once credentials land:

| App | Function | Replace with |
|---|---|---|
| `meta/` | `MetaApiClient._call()` | `requests.request(...)` with token auth |
| `attribution/` | `tasks._post_to_capi()` | `requests.post(graph.facebook.com/.../events)` |
| `crm/hubspot` | `push_lead()` | `requests.post(api.hubapi.com/crm/v3/objects/contacts)` |
| `crm/salesforce` | `push_lead()` | SF REST API call with OAuth header |
| `crm/generic_webhook` | `push_lead()` | `requests.post(connection.webhook_url, ...)` + HMAC sig |

## Out of scope

* SMS / RCS / Telegram trigger-emission — their inbound paths span multiple handlers; each lands as a follow-up issue. Substrate is channel-agnostic so each is a 4-line add.
* #193 Aisensy / WATI / Interakt / Yellow.ai `parse_referral` — those BSPs lack adapter classes today.
* #190 Meta App Review — operational, calendar-pending.
* Frontend (campaign wizard, dashboard, CRM UI) — lives in `jain-t/jina-connect-web`.

## Effort summary

Single PR delivering the entire CTWA backend in two commits. ~3500 LOC across 13 apps. Reviewable in chunks via the per-app directory boundaries. After this lands the only remaining backend work is filling in the 5 stub bodies above; the rest of the CTWA initiative is operational (#190) and frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)